### PR TITLE
Fix API key update logic and typo, update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Core config loader is exposed from [load_from_path()](crates/lightbridge-authz-c
   - Proto: [crates/lightbridge-authz-proto](crates/lightbridge-authz-proto/src/lib.rs:1)
 
 - Testing:
-  - Integration tests live in tests/ folders like [crates/lightbridge-authz-api/tests/basic.rs](crates/lightbridge-authz-api/tests/basic.rs:1).
+  - Integration tests live in tests/ folders like [crates/lightbridge-authz-rest/tests/api_tests.rs](crates/lightbridge-authz-rest/tests/api_tests.rs:1).
   - Run all: cargo test
 
 - Logging:

--- a/crates/lightbridge-authz-core/src/error.rs
+++ b/crates/lightbridge-authz-core/src/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
     #[error("Rand: {0}")]
     RandError(#[from] rand_core::OsError),
 
-    #[error("Address parse error error: {0}")]
+    #[error("Address parse error: {0}")]
     AddrParseError(#[from] std::net::AddrParseError),
 
     #[error("Database error: {0}")]

--- a/crates/lightbridge-authz-rest/src/handlers.rs
+++ b/crates/lightbridge-authz-rest/src/handlers.rs
@@ -53,9 +53,9 @@ impl APIKeyHandler for APIKeyHandlerImpl {
         // User authorization/ownership can be enforced at a higher layer or here when needed.
         let acl = input.acl.unwrap_or_default();
         let patch_api_key = PatchApiKey {
-            expires_at: None,
-            metadata: None,
-            status: None,
+            expires_at: input.expires_at,
+            metadata: input.metadata,
+            status: input.status,
             acl: Some(acl),
         };
         self.repo.update(&user_id, &api_key_id, patch_api_key).await


### PR DESCRIPTION
## Summary
- fix duplicated word in `AddrParseError` message
- persist API key updates for expiry and status
- clarify README test location and forward patch fields in REST handler

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b16265d6a48329b2596356621123cd