### PR TITLE
docs: clarify grpc authz architecture

### DIFF
--- a/docs/grpc-external-authz.md
+++ b/docs/grpc-external-authz.md
@@ -4,7 +4,7 @@
 
 To provide a flexible and performant way to authorize requests at the edge using Envoy's external authorization feature. This service will centralize API key validation and ACL management, allowing for consistent policy enforcement across all services behind the gateway.
 
-## Actual
+## Architecture
 
 The gRPC external authorization service will be a standalone component that integrates with Envoy. It will expose a gRPC endpoint that Envoy can call for each incoming request to determine if it's authorized.
 


### PR DESCRIPTION
## Summary
- rename ambiguous `Actual` section to clearer `Architecture` in gRPC authz doc

## Testing
- `cargo test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b169a0303c8329ac2fb4cd7b6c3804