### PR TITLE
docs: reference API key ID in controllers

### DIFF
--- a/crates/lightbridge-authz-api/src/controllers/delete.rs
+++ b/crates/lightbridge-authz-api/src/controllers/delete.rs
@@ -10,16 +10,16 @@ use lightbridge_authz_bearer::TokenInfo;
 use lightbridge_authz_core::error::Error;
 use tracing::instrument;
 
-/// Handles the deletion of an API key by its key string.
+/// Handles the deletion of an API key by its ID.
 ///
 /// This function extracts the `APIKeyHandler` from the application state
-/// and the `key` from the request path. It then calls the `delete_api_key`
-/// method on the handler to delete the API key.
+/// and the `key` (API key ID) from the request path. It then calls the
+/// `delete_api_key` method on the handler to delete the API key.
 ///
 /// # Arguments
 ///
 /// * `State(state)` - The application state containing the `APIKeyHandler` implementation.
-/// * `Path(key)` - The API key string extracted from the request path.
+/// * `Path(key)` - The API key ID extracted from the request path.
 ///
 /// # Returns
 ///

--- a/crates/lightbridge-authz-api/src/controllers/get.rs
+++ b/crates/lightbridge-authz-api/src/controllers/get.rs
@@ -11,16 +11,16 @@ use lightbridge_authz_bearer::TokenInfo;
 use lightbridge_authz_core::error::Error;
 use tracing::instrument;
 
-/// Handles the retrieval of an API key by its key string.
+/// Handles the retrieval of an API key by its ID.
 ///
 /// This function extracts the `APIKeyHandler` from the application state
-/// and the `key` from the request path. It then calls the `get_api_key`
-/// method on the handler to retrieve the API key.
+/// and the `key` (API key ID) from the request path. It then calls the
+/// `get_api_key` method on the handler to retrieve the API key.
 ///
 /// # Arguments
 ///
 /// * `State(state)` - The application state containing the `APIKeyHandler` implementation.
-/// * `Path(key)` - The API key string extracted from the request path.
+/// * `Path(key)` - The API key ID extracted from the request path.
 ///
 /// # Returns
 ///

--- a/crates/lightbridge-authz-api/src/controllers/patch.rs
+++ b/crates/lightbridge-authz-api/src/controllers/patch.rs
@@ -15,14 +15,14 @@ use tracing::instrument;
 /// Handles the update of an existing API key.
 ///
 /// This function extracts the `APIKeyHandler` from the application state,
-/// the `key` from the request path, and the `PatchApiKey` payload
+/// the `key` (API key ID) from the request path, and the `PatchApiKey` payload
 /// from the request body. It then calls the `patch_api_key` method on the handler
 /// to update the API key.
 ///
 /// # Arguments
 ///
 /// * `State(state)` - The application state containing the `APIKeyHandler` implementation.
-/// * `Path(key)` - The API key string extracted from the request path.
+/// * `Path(key)` - The API key ID extracted from the request path.
 /// * `Json(input)` - The JSON payload containing the data to patch the API key with.
 ///
 /// # Returns


### PR DESCRIPTION
## Summary
- clarify controller docs to reference API key ID instead of key string

## Testing
- `cargo test -p lightbridge-authz-api`

------
https://chatgpt.com/codex/tasks/task_e_68b169b4dfd08329a15d21eac39f0115