### PR TITLE
Pass through API key expiry and metadata

### DIFF
--- a/crates/lightbridge-authz-rest/src/handlers.rs
+++ b/crates/lightbridge-authz-rest/src/handlers.rs
@@ -36,8 +36,8 @@ impl APIKeyHandler for APIKeyHandlerImpl {
         let acl: Acl = input.acl.unwrap_or_default();
 
         let create_api_key = CreateApiKey {
-            expires_at: None,
-            metadata: None,
+            expires_at: input.expires_at,
+            metadata: input.metadata,
             acl: Some(acl),
         };
         let key_plain = format!("sk-{}-{}", cuid2_slug(), cuid2());
@@ -53,9 +53,9 @@ impl APIKeyHandler for APIKeyHandlerImpl {
         // User authorization/ownership can be enforced at a higher layer or here when needed.
         let acl = input.acl.unwrap_or_default();
         let patch_api_key = PatchApiKey {
-            expires_at: None,
-            metadata: None,
-            status: None,
+            expires_at: input.expires_at,
+            metadata: input.metadata,
+            status: input.status,
             acl: Some(acl),
         };
         self.repo.update(&user_id, &api_key_id, patch_api_key).await

--- a/crates/lightbridge-authz-rest/tests/api_tests.rs
+++ b/crates/lightbridge-authz-rest/tests/api_tests.rs
@@ -5,6 +5,8 @@ use lightbridge_authz_core::error::Error;
 use lightbridge_authz_rest::handlers::APIKeyHandlerImpl;
 use std::collections::HashMap;
 use std::sync::Arc;
+use chrono::{Duration, Utc};
+use serde_json::json;
 
 // Inlined mock_repository module for integration tests
 mod mock_repository {
@@ -143,9 +145,11 @@ async fn test_create_api_key_success() {
     };
 
     let user_id = "user123".to_string();
+    let expires_at = Utc::now() + Duration::days(30);
+    let metadata = json!({"purpose": "test"});
     let create_input = CreateApiKey {
-        expires_at: None,
-        metadata: None,
+        expires_at: Some(expires_at),
+        metadata: Some(metadata.clone()),
         acl: Some(Acl::default()),
     };
 
@@ -156,6 +160,8 @@ async fn test_create_api_key_success() {
 
     assert_eq!(api_key.user_id, user_id);
     assert_eq!(api_key.status, ApiKeyStatus::Active);
+    assert_eq!(api_key.expires_at, Some(expires_at));
+    assert_eq!(api_key.metadata, Some(metadata.clone()));
 
     let fetched_key = mock_repo
         .find_by_id(&user_id, &api_key.id)
@@ -163,6 +169,8 @@ async fn test_create_api_key_success() {
         .unwrap()
         .unwrap();
     assert_eq!(fetched_key.id, api_key.id);
+    assert_eq!(fetched_key.expires_at, Some(expires_at));
+    assert_eq!(fetched_key.metadata, Some(metadata));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- forward `expires_at` and `metadata` when creating or patching API keys
- test that API key creation persists supplied `expires_at` and `metadata`

## Testing
- `cargo test -p lightbridge-authz-rest`


------
https://chatgpt.com/codex/tasks/task_e_68b169aa3c1483298e61359d666cb85c