### PR TITLE
Add OAuth2 token issuance for API key creation and rotation

### DIFF
--- a/.docker/authz/container.yaml
+++ b/.docker/authz/container.yaml
@@ -21,6 +21,13 @@ database:
   pool_size: 10
 oauth2:
   jwks_url: "http://keycloak:9100/realms/dev/protocol/openid-connect/certs"
+  oauth2_url: "http://keycloak:9100/realms/dev/protocol/openid-connect/token"
+  issuance:
+    enabled: true
+    grant_type: "urn:ietf:params:oauth:grant-type:token-exchange"
+    client_id: "${KEYCLOAK_TOKEN_CLIENT_ID:-test-client}"
+    subject_token_type: "urn:ietf:params:oauth:token-type:access_token"
+    requested_token_type: "urn:ietf:params:oauth:token-type:access_token"
 otel:
   enabled: true
   otlp_endpoint: "http://jaeger:4317"

--- a/.docker/keycloak_config/realm.json
+++ b/.docker/keycloak_config/realm.json
@@ -61,7 +61,7 @@
         "realm_client": "false",
         "oidc.ciba.grant.enabled": "false",
         "backchannel.logout.session.required": "true",
-        "standard.token.exchange.enabled": "false",
+        "standard.token.exchange.enabled": "true",
         "oauth2.device.authorization.grant.enabled": "false",
         "backchannel.logout.revoke.offline.tokens": "false"
       },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -2528,6 +2528,7 @@ dependencies = [
  "chrono",
  "getrandom 0.4.2",
  "goose",
+ "httpmock",
  "lightbridge-authz-api",
  "lightbridge-authz-api-key",
  "lightbridge-authz-bearer",
@@ -3685,6 +3686,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3919,9 +3921,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,8 @@ chrono = { version = "0.4", features = ["serde"] }
 cuid = { version = "1" }
 getrandom = "0.4"
 goose = "0.18"
-reqwest = { version = "0.13", features = ["json"] }
+httpmock = "0.7"
+reqwest = { version = "0.13", features = ["json", "form"] }
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "chrono", "json", "macros"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 utoipa = { version = "5", features = ["macros", "chrono"] }

--- a/README.md
+++ b/README.md
@@ -86,14 +86,18 @@ Default container config is mounted from `.docker/authz/container.yaml`:
 - Lifecycle: `POST /api-keys/{key_id}/revoke`, `POST /api-keys/{key_id}/rotate`
 - OpenAPI docs: `https://localhost:13000/api/v1/docs`
 
-**OPA API (Basic Auth)**
+**Internal Authz/Authorino validation API (Basic Auth)**
 - `POST /v1/opa/validate`
 - `POST /v1/authorino/validate` (supports dynamic metadata passthrough/enrichment)
 - OpenAPI docs: `https://localhost:13001/v1/opa/docs`
 
-Use this endpoint from Authorino’s OPA external authz policy to validate API keys; send the presented API key and optional client IP.
+This backend is intended to be called by Authorino, not by end users or client
+applications directly. Authorino sends the presented credential and request
+metadata, and the validation backend rejects revoked or expired credentials before
+returning enriched `api_key`, `project`, and `account` context for policy and
+upstream request metadata.
 
-Example:
+Manual validation example:
 
 ```bash
 curl -k -u authorino:change-me \
@@ -154,7 +158,7 @@ Keycloak is preloaded with:
 API key creation uses Keycloak token exchange in dev: the API exchanges the
 caller's bearer token at the same realm token endpoint and stores the hash of the
 exchanged access token. See `docs/test-protocol.md` for the same-realm token
-exchange notes and the requester/target client distinction.
+exchange notes, the requester/target client distinction, and revocation behavior.
 
 ### Option A: Enable direct access grants (recommended for quick local testing)
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ Keycloak is preloaded with:
 - User: `test@admin` / `test` (email-as-username)
 - Client: `test-client` (public)
 
+API key creation uses Keycloak token exchange in dev: the API exchanges the
+caller's bearer token at the same realm token endpoint and stores the hash of the
+exchanged access token. See `docs/test-protocol.md` for the same-realm token
+exchange notes and the requester/target client distinction.
+
 ### Option A: Enable direct access grants (recommended for quick local testing)
 
 1. Open Keycloak admin: `http://localhost:9100`  

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -21,6 +21,13 @@ database:
   pool_size: 10
 oauth2:
   jwks_url: "http://localhost:9100/realms/dev/protocol/openid-connect/certs"
+  oauth2_url: "http://localhost:9100/realms/dev/protocol/openid-connect/token"
+  issuance:
+    enabled: true
+    grant_type: "urn:ietf:params:oauth:grant-type:token-exchange"
+    client_id: "${KEYCLOAK_TOKEN_CLIENT_ID:-test-client}"
+    subject_token_type: "urn:ietf:params:oauth:token-type:access_token"
+    requested_token_type: "urn:ietf:params:oauth:token-type:access_token"
 otel:
   enabled: true
   otlp_endpoint: "http://localhost:4317"

--- a/crates/lightbridge-authz-api/src/controllers/api_keys.rs
+++ b/crates/lightbridge-authz-api/src/controllers/api_keys.rs
@@ -33,7 +33,7 @@ pub async fn create_api_key(
     let subject = token_info.sub.clone();
     let api_key = state
         .store
-        .create_api_key(&subject, &project_id, input)
+        .create_api_key(&subject, Some(&token_info.access_token), &project_id, input)
         .await?;
     Ok((StatusCode::CREATED, Json(api_key)))
 }
@@ -176,6 +176,9 @@ pub async fn rotate_api_key(
     Json(input): Json<RotateApiKey>,
 ) -> Result<impl IntoResponse, Error> {
     let subject = token_info.sub.clone();
-    let api_key = state.store.rotate_api_key(&subject, &key_id, input).await?;
+    let api_key = state
+        .store
+        .rotate_api_key(&subject, Some(&token_info.access_token), &key_id, input)
+        .await?;
     Ok((StatusCode::CREATED, Json(api_key)))
 }

--- a/crates/lightbridge-authz-api/src/store.rs
+++ b/crates/lightbridge-authz-api/src/store.rs
@@ -47,6 +47,7 @@ pub trait AuthzStore: Send + Sync + 'static + std::fmt::Debug {
     async fn create_api_key(
         &self,
         subject: &str,
+        bearer_token: Option<&str>,
         project_id: &str,
         input: CreateApiKey,
     ) -> Result<ApiKeySecret, Error>;
@@ -69,6 +70,7 @@ pub trait AuthzStore: Send + Sync + 'static + std::fmt::Debug {
     async fn rotate_api_key(
         &self,
         subject: &str,
+        bearer_token: Option<&str>,
         key_id: &str,
         input: RotateApiKey,
     ) -> Result<ApiKeySecret, Error>;

--- a/crates/lightbridge-authz-bearer/Cargo.toml
+++ b/crates/lightbridge-authz-bearer/Cargo.toml
@@ -18,5 +18,5 @@ tokio.workspace = true
 tokio.features = ["macros", "rt-multi-thread", "sync"]
 
 [dev-dependencies]
-httpmock = "0.7"
+httpmock.workspace = true
 serde_json.workspace = true

--- a/crates/lightbridge-authz-bearer/src/lib.rs
+++ b/crates/lightbridge-authz-bearer/src/lib.rs
@@ -17,6 +17,8 @@ pub struct TokenInfo {
     pub active: bool,
     pub sub: String,
     pub exp: u64,
+    #[serde(default)]
+    pub access_token: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -165,6 +167,7 @@ impl BearerTokenServiceTrait for BearerTokenService {
             active: true,
             sub: claims.sub,
             exp: claims.exp,
+            access_token: token.to_string(),
         })
     }
 }

--- a/crates/lightbridge-authz-core/src/config/mod.rs
+++ b/crates/lightbridge-authz-core/src/config/mod.rs
@@ -76,6 +76,8 @@ pub struct Database {
 pub struct Oauth2 {
     pub jwks_url: String,
     #[serde(default)]
+    pub oauth2_url: Option<String>,
+    #[serde(default)]
     pub issuer_url: Option<String>,
     #[serde(default)]
     pub authorization_endpoint: Option<String>,
@@ -83,6 +85,28 @@ pub struct Oauth2 {
     pub token_endpoint: Option<String>,
     #[serde(default)]
     pub registration_endpoint: Option<String>,
+    #[serde(default)]
+    pub issuance: Option<Oauth2Issuance>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Oauth2Issuance {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub grant_type: Option<String>,
+    #[serde(default)]
+    pub client_id: String,
+    #[serde(default)]
+    pub client_secret: Option<String>,
+    #[serde(default)]
+    pub subject_token_type: Option<String>,
+    #[serde(default)]
+    pub requested_token_type: Option<String>,
+    #[serde(default)]
+    pub audience: Option<String>,
+    #[serde(default)]
+    pub scope: Option<String>,
 }
 
 pub fn load_from_path<P: AsRef<std::path::Path>>(path: P) -> Result<Config> {

--- a/crates/lightbridge-authz-core/src/dto.rs
+++ b/crates/lightbridge-authz-core/src/dto.rs
@@ -135,4 +135,6 @@ pub struct RotateApiKey {
 pub struct ApiKeySecret {
     pub api_key: ApiKey,
     pub secret: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth2_url: Option<String>,
 }

--- a/crates/lightbridge-authz-mcp/src/lib.rs
+++ b/crates/lightbridge-authz-mcp/src/lib.rs
@@ -190,6 +190,12 @@ fn normalize_list_pagination(offset: u32, limit: u32) -> (u32, u32) {
 fn subject_from_request_context(
     context: &RequestContext<RoleServer>,
 ) -> std::result::Result<String, ErrorData> {
+    Ok(token_info_from_request_context(context)?.sub.clone())
+}
+
+fn token_info_from_request_context(
+    context: &RequestContext<RoleServer>,
+) -> std::result::Result<TokenInfo, ErrorData> {
     let parts = context
         .extensions
         .get::<axum::http::request::Parts>()
@@ -200,7 +206,7 @@ fn subject_from_request_context(
         .get::<TokenInfo>()
         .ok_or_else(|| ErrorData::internal_error("missing bearer token context", None))?;
 
-    Ok(token_info.sub.clone())
+    Ok(token_info.clone())
 }
 
 fn issuer_from_jwks_url(jwks_url: &str) -> Option<String> {
@@ -238,6 +244,7 @@ fn resolve_oauth2_endpoints(oauth2: &Oauth2) -> Option<Oauth2ResolvedEndpoints> 
     let token_endpoint = oauth2
         .token_endpoint
         .clone()
+        .or_else(|| oauth2.oauth2_url.clone())
         .unwrap_or_else(|| join_issuer_path(&issuer, "protocol/openid-connect/token"));
     let registration_endpoint = oauth2
         .registration_endpoint
@@ -747,13 +754,15 @@ impl LightbridgeMcpHandler {
         context: RequestContext<RoleServer>,
         Parameters(params): Parameters<CreateApiKeyParams>,
     ) -> std::result::Result<Json<EndpointResponse>, ErrorData> {
-        let subject = subject_from_request_context(&context)?;
+        let token_info = token_info_from_request_context(&context)?;
+        let subject = token_info.sub.clone();
         let expires_at = parse_optional_datetime(params.expires_at, "expires_at")?;
 
         let api_key_secret: ApiKeySecret = self
             .store
             .create_api_key(
                 &subject,
+                Some(&token_info.access_token),
                 &params.project_id,
                 CreateApiKey {
                     name: params.name,
@@ -879,13 +888,15 @@ impl LightbridgeMcpHandler {
         context: RequestContext<RoleServer>,
         Parameters(params): Parameters<RotateApiKeyParams>,
     ) -> std::result::Result<Json<EndpointResponse>, ErrorData> {
-        let subject = subject_from_request_context(&context)?;
+        let token_info = token_info_from_request_context(&context)?;
+        let subject = token_info.sub.clone();
         let expires_at = parse_optional_datetime(params.expires_at, "expires_at")?;
 
         let api_key_secret = self
             .store
             .rotate_api_key(
                 &subject,
+                Some(&token_info.access_token),
                 &params.key_id,
                 RotateApiKey {
                     name: params.name,
@@ -1186,6 +1197,7 @@ mod tests {
         async fn create_api_key(
             &self,
             _subject: &str,
+            _bearer_token: Option<&str>,
             _project_id: &str,
             _input: CreateApiKey,
         ) -> std::result::Result<ApiKeySecret, Error> {
@@ -1238,6 +1250,7 @@ mod tests {
         async fn rotate_api_key(
             &self,
             _subject: &str,
+            _bearer_token: Option<&str>,
             _key_id: &str,
             _input: RotateApiKey,
         ) -> std::result::Result<ApiKeySecret, Error> {
@@ -1336,10 +1349,12 @@ mod tests {
     fn sample_oauth2() -> Oauth2 {
         Oauth2 {
             jwks_url: "http://keycloak:9100/realms/dev/protocol/openid-connect/certs".to_string(),
+            oauth2_url: None,
             issuer_url: None,
             authorization_endpoint: None,
             token_endpoint: None,
             registration_endpoint: None,
+            issuance: None,
         }
     }
 

--- a/crates/lightbridge-authz-rest/Cargo.toml
+++ b/crates/lightbridge-authz-rest/Cargo.toml
@@ -19,6 +19,7 @@ chrono.workspace = true
 base64.workspace = true
 axum-server.workspace = true
 getrandom.workspace = true
+reqwest.workspace = true
 rustls.workspace = true
 lightbridge-authz-api.workspace = true
 lightbridge-authz-core = { workspace = true, features = ["axum"] }
@@ -34,6 +35,7 @@ anyhow.workspace = true
 goose.workspace = true
 reqwest.workspace = true
 sqlx.workspace = true
+httpmock.workspace = true
 
 [features]
 load-tests = []

--- a/crates/lightbridge-authz-rest/src/handlers/mod.rs
+++ b/crates/lightbridge-authz-rest/src/handlers/mod.rs
@@ -9,16 +9,23 @@ use getrandom::fill;
 use lightbridge_authz_api::contract::AuthzStore;
 use lightbridge_authz_api_key::repo::StoreRepo;
 use lightbridge_authz_core::async_trait;
+use lightbridge_authz_core::config::{Oauth2, Oauth2Issuance};
 use lightbridge_authz_core::cuid::cuid2;
 use lightbridge_authz_core::{
     Account, ApiKey, ApiKeySecret, ApiKeyStatus, CreateAccount, CreateApiKey, CreateProject,
     Project, RotateApiKey, UpdateAccount, UpdateApiKey, UpdateProject, hash_api_key,
 };
-use lightbridge_authz_core::{db::DbPoolTrait, error::Result};
+use lightbridge_authz_core::{
+    db::DbPoolTrait,
+    error::{Error, Result},
+};
+use reqwest::Client;
+use serde::Deserialize;
 
 #[derive(Clone)]
 pub struct AuthzStoreImpl {
     repo: Arc<StoreRepo>,
+    token_issuer: Option<OAuth2TokenIssuer>,
 }
 
 impl std::fmt::Debug for AuthzStoreImpl {
@@ -32,6 +39,15 @@ impl AuthzStoreImpl {
         let repo = StoreRepo::new(pool);
         Self {
             repo: Arc::new(repo),
+            token_issuer: None,
+        }
+    }
+
+    pub fn with_pool_and_oauth2(pool: Arc<dyn DbPoolTrait>, oauth2: &Oauth2) -> Self {
+        let repo = StoreRepo::new(pool);
+        Self {
+            repo: Arc::new(repo),
+            token_issuer: OAuth2TokenIssuer::from_config(oauth2),
         }
     }
 
@@ -51,6 +67,131 @@ impl AuthzStoreImpl {
             secret.chars().take(8).collect()
         }
     }
+
+    async fn issue_secret(&self, bearer_token: Option<&str>) -> Result<IssuedSecret> {
+        if let Some(token_issuer) = &self.token_issuer {
+            token_issuer.issue(bearer_token).await
+        } else {
+            Ok(IssuedSecret {
+                secret: Self::generate_secret()?,
+                expires_at: None,
+                oauth2_url: None,
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IssuedSecret {
+    secret: String,
+    expires_at: Option<DateTime<Utc>>,
+    oauth2_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct OAuth2TokenIssuer {
+    client: Client,
+    oauth2_url: String,
+    issuance: Oauth2Issuance,
+}
+
+#[derive(Debug, Deserialize)]
+struct OAuth2TokenResponse {
+    access_token: String,
+    expires_in: Option<i64>,
+}
+
+impl OAuth2TokenIssuer {
+    fn from_config(oauth2: &Oauth2) -> Option<Self> {
+        let issuance = oauth2.issuance.clone()?;
+        if !issuance.enabled {
+            return None;
+        }
+        let oauth2_url = oauth2
+            .oauth2_url
+            .clone()
+            .or_else(|| oauth2.token_endpoint.clone())?;
+        Some(Self {
+            client: Client::new(),
+            oauth2_url,
+            issuance,
+        })
+    }
+
+    fn grant_type(&self) -> &str {
+        self.issuance
+            .grant_type
+            .as_deref()
+            .unwrap_or("urn:ietf:params:oauth:grant-type:token-exchange")
+    }
+
+    async fn issue(&self, bearer_token: Option<&str>) -> Result<IssuedSecret> {
+        let grant_type = self.grant_type();
+        if self.issuance.client_id.trim().is_empty() {
+            return Err(Error::Server(
+                "oauth2 issuance client_id is required".to_string(),
+            ));
+        }
+        let subject_token = bearer_token
+            .filter(|token| !token.trim().is_empty())
+            .ok_or_else(|| Error::Server("oauth2 issuance bearer token is required".to_string()))?;
+        let mut form = vec![
+            ("grant_type".to_string(), grant_type.to_string()),
+            ("client_id".to_string(), self.issuance.client_id.clone()),
+            ("subject_token".to_string(), subject_token.to_string()),
+            (
+                "subject_token_type".to_string(),
+                self.issuance
+                    .subject_token_type
+                    .clone()
+                    .unwrap_or_else(|| "urn:ietf:params:oauth:token-type:access_token".to_string()),
+            ),
+        ];
+
+        if let Some(client_secret) = &self.issuance.client_secret {
+            form.push(("client_secret".to_string(), client_secret.clone()));
+        }
+        if let Some(requested_token_type) = &self.issuance.requested_token_type {
+            form.push((
+                "requested_token_type".to_string(),
+                requested_token_type.clone(),
+            ));
+        }
+        if let Some(audience) = &self.issuance.audience {
+            form.push(("audience".to_string(), audience.clone()));
+        }
+        if let Some(scope) = &self.issuance.scope {
+            form.push(("scope".to_string(), scope.clone()));
+        }
+
+        let response = self
+            .client
+            .post(&self.oauth2_url)
+            .form(&form)
+            .send()
+            .await
+            .map_err(|e| Error::Server(format!("oauth2 token issuance request failed: {e}")))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Error::Server(format!(
+                "oauth2 token issuance failed with status {status}: {body}"
+            )));
+        }
+        let token = response
+            .json::<OAuth2TokenResponse>()
+            .await
+            .map_err(|e| Error::Server(format!("oauth2 token response parse failed: {e}")))?;
+        let expires_at = token
+            .expires_in
+            .filter(|seconds| *seconds > 0)
+            .map(|seconds| Utc::now() + Duration::seconds(seconds));
+        Ok(IssuedSecret {
+            secret: token.access_token,
+            expires_at,
+            oauth2_url: Some(self.oauth2_url.clone()),
+        })
+    }
 }
 
 fn resolve_rotated_expires_at(
@@ -58,6 +199,18 @@ fn resolve_rotated_expires_at(
     existing: Option<DateTime<Utc>>,
 ) -> Option<DateTime<Utc>> {
     input.or(existing)
+}
+
+fn resolve_issued_expires_at(
+    requested: Option<DateTime<Utc>>,
+    issued: Option<DateTime<Utc>>,
+) -> Option<DateTime<Utc>> {
+    match (requested, issued) {
+        (Some(requested), Some(issued)) => Some(requested.min(issued)),
+        (Some(requested), None) => Some(requested),
+        (None, Some(issued)) => Some(issued),
+        (None, None) => None,
+    }
 }
 
 #[async_trait]
@@ -136,13 +289,15 @@ impl AuthzStore for AuthzStoreImpl {
     async fn create_api_key(
         &self,
         subject: &str,
+        bearer_token: Option<&str>,
         project_id: &str,
         input: CreateApiKey,
     ) -> Result<ApiKeySecret> {
-        let secret = Self::generate_secret()?;
-        let key_hash = hash_api_key(&secret);
-        let key_prefix = Self::key_prefix(&secret);
+        let issued = self.issue_secret(bearer_token).await?;
+        let key_hash = hash_api_key(&issued.secret);
+        let key_prefix = Self::key_prefix(&issued.secret);
         let now = Utc::now();
+        let expires_at = resolve_issued_expires_at(input.expires_at, issued.expires_at);
         let row = lightbridge_authz_api_key::entities::new_api_key_row::NewApiKeyRow {
             id: cuid2(),
             project_id: project_id.to_string(),
@@ -150,14 +305,18 @@ impl AuthzStore for AuthzStoreImpl {
             key_prefix,
             key_hash,
             created_at: now,
-            expires_at: input.expires_at,
+            expires_at,
             status: ApiKeyStatus::Active.to_string(),
             last_used_at: None,
             last_ip: None,
             revoked_at: None,
         };
         let api_key = self.repo.create_api_key(subject, row).await?;
-        Ok(ApiKeySecret { api_key, secret })
+        Ok(ApiKeySecret {
+            api_key,
+            secret: issued.secret,
+            oauth2_url: issued.oauth2_url,
+        })
     }
 
     async fn list_api_keys(
@@ -207,6 +366,7 @@ impl AuthzStore for AuthzStoreImpl {
     async fn rotate_api_key(
         &self,
         subject: &str,
+        bearer_token: Option<&str>,
         key_id: &str,
         input: RotateApiKey,
     ) -> Result<ApiKeySecret> {
@@ -229,10 +389,12 @@ impl AuthzStore for AuthzStoreImpl {
                 (ApiKeyStatus::Revoked, Some(now), None)
             };
 
-        let secret = Self::generate_secret()?;
-        let key_hash = hash_api_key(&secret);
-        let key_prefix = Self::key_prefix(&secret);
-        let expires_at = resolve_rotated_expires_at(input.expires_at, existing.expires_at);
+        let issued = self.issue_secret(bearer_token).await?;
+        let key_hash = hash_api_key(&issued.secret);
+        let key_prefix = Self::key_prefix(&issued.secret);
+        let requested_expires_at =
+            resolve_rotated_expires_at(input.expires_at, existing.expires_at);
+        let expires_at = resolve_issued_expires_at(requested_expires_at, issued.expires_at);
         let row = lightbridge_authz_api_key::entities::new_api_key_row::NewApiKeyRow {
             id: cuid2(),
             project_id: existing.project_id,
@@ -250,14 +412,21 @@ impl AuthzStore for AuthzStoreImpl {
             .repo
             .rotate_api_key_transaction(subject, key_id, status, revoked_at, old_expires_at, row)
             .await?;
-        Ok(ApiKeySecret { api_key, secret })
+        Ok(ApiKeySecret {
+            api_key,
+            secret: issued.secret,
+            oauth2_url: issued.oauth2_url,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_rotated_expires_at;
+    use super::{OAuth2TokenIssuer, resolve_issued_expires_at, resolve_rotated_expires_at};
     use chrono::{Duration, Utc};
+    use httpmock::{Method::POST, MockServer};
+    use lightbridge_authz_core::config::{Oauth2, Oauth2Issuance};
+    use serde_json::json;
 
     #[test]
     fn rotate_defaults_to_existing_expiry_when_missing() {
@@ -283,5 +452,73 @@ mod tests {
     #[test]
     fn rotate_returns_none_when_no_expiry() {
         assert_eq!(resolve_rotated_expires_at(None, None), None);
+    }
+
+    #[test]
+    fn issued_expiry_prefers_earliest_timestamp() {
+        let base_time = Utc::now();
+        let requested = base_time + Duration::minutes(10);
+        let issued = base_time + Duration::minutes(5);
+
+        assert_eq!(
+            resolve_issued_expires_at(Some(requested), Some(issued)),
+            Some(issued)
+        );
+    }
+
+    #[tokio::test]
+    async fn oauth2_issuer_posts_token_exchange_and_returns_access_token() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/token")
+                .body_contains(
+                    "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange",
+                )
+                .body_contains("client_id=test-client")
+                .body_contains("subject_token=incoming-access-token")
+                .body_contains(
+                    "subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token",
+                )
+                .body_contains(
+                    "requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token",
+                );
+            then.status(200).json_body(json!({
+                "access_token": "issued-access-token",
+                "expires_in": 60,
+                "token_type": "Bearer"
+            }));
+        });
+        let oauth2_url = server.url("/token");
+        let issuer = OAuth2TokenIssuer::from_config(&Oauth2 {
+            jwks_url: server.url("/jwks"),
+            oauth2_url: Some(oauth2_url.clone()),
+            issuer_url: None,
+            authorization_endpoint: None,
+            token_endpoint: None,
+            registration_endpoint: None,
+            issuance: Some(Oauth2Issuance {
+                enabled: true,
+                grant_type: Some("urn:ietf:params:oauth:grant-type:token-exchange".to_string()),
+                client_id: "test-client".to_string(),
+                client_secret: None,
+                subject_token_type: Some(
+                    "urn:ietf:params:oauth:token-type:access_token".to_string(),
+                ),
+                requested_token_type: Some(
+                    "urn:ietf:params:oauth:token-type:access_token".to_string(),
+                ),
+                audience: None,
+                scope: None,
+            }),
+        })
+        .expect("issuer should be configured");
+
+        let issued = issuer.issue(Some("incoming-access-token")).await.unwrap();
+
+        assert_eq!(issued.secret, "issued-access-token");
+        assert_eq!(issued.oauth2_url, Some(oauth2_url));
+        assert!(issued.expires_at.is_some());
+        assert_eq!(mock.hits(), 1);
     }
 }

--- a/crates/lightbridge-authz-rest/src/lib.rs
+++ b/crates/lightbridge-authz-rest/src/lib.rs
@@ -93,7 +93,7 @@ pub async fn start_api_server(
     oauth2: &Oauth2,
 ) -> Result<()> {
     let readiness_pool = pool.clone();
-    let store = Arc::new(AuthzStoreImpl::with_pool(pool));
+    let store = Arc::new(AuthzStoreImpl::with_pool_and_oauth2(pool, oauth2));
     let bearer_service: Arc<dyn lightbridge_authz_bearer::BearerTokenServiceTrait> =
         Arc::new(BearerTokenService::new(oauth2.clone()));
 

--- a/docs/test-protocol.md
+++ b/docs/test-protocol.md
@@ -1,9 +1,9 @@
-# Test Protocol (OAuth2 + OPA)
+# Test Protocol (OAuth2 + Authorino Validation)
 
 This protocol validates the full flow:
 1) OAuth2‑protected CRUD API
 2) API key creation
-3) OPA validation with usage telemetry
+3) Authorino-facing validation with usage telemetry and enrichment
 
 ## Prerequisites
 - Docker Compose services are running
@@ -92,6 +92,14 @@ itself. In Keycloak, the client making the exchange must have standard token
 exchange enabled and, for confidential clients, authenticate with its configured
 client authentication method.
 
+Revoking the API key invalidates the credential at the Lightbridge validation
+layer immediately. The validation backend stores only the exchanged token hash and
+checks the `api_keys` row status before returning any enrichment, so a revoked key
+is rejected when Authorino asks Lightbridge to authorize a request. This does not
+revoke the OAuth2 token at Keycloak/provider level; if that token is usable
+outside the Authorino-to-Lightbridge validation path, keep its audience narrow and
+its lifetime short or add provider-side revocation/introspection.
+
 ```bash
 KEY_JSON=$(curl -k -s https://localhost:13000/api/v1/projects/$PROJECT_ID/api-keys \
   -H "Authorization: Bearer $TOKEN" \
@@ -101,7 +109,7 @@ KEY_JSON=$(curl -k -s https://localhost:13000/api/v1/projects/$PROJECT_ID/api-ke
 SECRET=$(echo "$KEY_JSON" | /usr/bin/python3 -c "import sys, json; print(json.load(sys.stdin)['secret'])")
 ```
 
-## 6) Validate via OPA (basic auth)
+## 6) Validate through the internal Authorino backend
 
 ```bash
 curl -k -u authorino:change-me https://localhost:13001/v1/opa/validate \
@@ -110,6 +118,11 @@ curl -k -u authorino:change-me https://localhost:13001/v1/opa/validate \
 ```
 
 Expected: `200` with `api_key`, `project`, and `account` fields, and `last_used_at` populated.
+
+In a deployed path, callers do not invoke this backend directly. Authorino calls
+the validation endpoint using basic auth, then uses the returned context to enrich
+the authorized request with account, project, API key, and any preserved request
+metadata.
 
 ## Cleanup (optional)
 

--- a/docs/test-protocol.md
+++ b/docs/test-protocol.md
@@ -78,6 +78,20 @@ PROJECT_ID=$(echo "$PROJECT_JSON" | /usr/bin/python3 -c "import sys, json; print
 
 ## 5) Create an API key
 
+In dev, API key creation is backed by Keycloak token exchange. The CRUD API sends
+the caller's validated bearer token to the realm token endpoint as `subject_token`
+and stores only the hash of the exchanged access token. The returned `secret` is
+therefore an OAuth2 access token issued on behalf of the same user, not a locally
+generated random string.
+
+Keycloak standard token exchange is same-realm internal token exchange. The input
+token and the newly issued token both come from realm `dev`; the useful boundary is
+the client context. For production-like setups, prefer a dedicated target client
+or audience for API-key credentials instead of exchanging `test-client` back to
+itself. In Keycloak, the client making the exchange must have standard token
+exchange enabled and, for confidential clients, authenticate with its configured
+client authentication method.
+
 ```bash
 KEY_JSON=$(curl -k -s https://localhost:13000/api/v1/projects/$PROJECT_ID/api-keys \
   -H "Authorization: Bearer $TOKEN" \


### PR DESCRIPTION
## Summary
- Add optional OAuth2 token exchange support for API key create and rotate flows in dev/local configs.
- Thread the caller’s bearer token through authz API and MCP handlers so issued API keys can be backed by exchanged access tokens.
- Extend config and docs for Keycloak token exchange, including realm changes and request/response metadata.
- Add tests for token exchange request formation, expiry resolution, and handler/store wiring.

## Testing
- Added unit coverage for token exchange issuance and expiry selection logic.
- Updated existing handler/store tests to account for bearer-token propagation.
- Not run (not requested).