### PR TITLE
Clarify usage API contract and add frontend integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Lightbridge Authz is a multi-service backend for API key management and usage an
   - Reuses the same config file as `lightbridge-authz` (API bind/tls + shared DB settings).
 - **lightbridge-authz-usage** (OTEL ingest + usage query)
   - OTEL ingest endpoints (no auth): `POST /v1/otel/traces`, `POST /v1/otel/metrics`
-  - Usage query endpoint: `POST /v1/usage/query`
-  - OpenAPI docs: `/v1/usage/docs`
+  - Usage query endpoint: `POST /usage/v1/usage/query`
+  - OpenAPI docs: `/usage/v1/usage/docs`
   - Probe routes: `GET /health`, `GET /health/startup`, `GET /health/ready`
 - **postgresql**, **keycloak**, **adminer**, **authz-tls**
 
@@ -118,7 +118,7 @@ Detailed usage + integration test guide:
 **Usage API (No auth on ingest/query endpoints)**
 - `POST /v1/otel/traces` (OTLP/HTTP traces, protobuf or JSON)
 - `POST /v1/otel/metrics` (OTLP/HTTP metrics, protobuf or JSON)
-- `POST /v1/usage/query` (bucketed timeseries for `user`, `project`, or `account` scopes)
+- `POST /usage/v1/usage/query` (bucketed timeseries for `user`, `project`, or `account` scopes)
 
 Example query body:
 

--- a/crates/lightbridge-authz-core/src/error.rs
+++ b/crates/lightbridge-authz-core/src/error.rs
@@ -55,9 +55,14 @@ mod axum_impl {
         }
     }
 
-    impl IntoResponse for Error {
-        fn into_response(self) -> axum::response::Response {
-            let status_code = match &self {
+    impl Error {
+        /// HTTP status code used when this error is returned from an API handler.
+        ///
+        /// Transient SQLx pool failures (`PoolTimedOut`, `PoolClosed`,
+        /// `WorkerCrashed`) map to `503 Service Unavailable` so clients and load
+        /// balancers retain the retryable signal.
+        pub fn status_code(&self) -> StatusCode {
+            match self {
                 Error::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 Error::Yaml(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 Error::NotFound => StatusCode::NOT_FOUND,
@@ -66,11 +71,14 @@ mod axum_impl {
                 Error::AddrParseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 Error::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 Error::Server(_) => StatusCode::INTERNAL_SERVER_ERROR,
-
                 Error::SqlxError(err) => sqlx_status_code(err),
-            };
+            }
+        }
+    }
 
-            (status_code, self.to_string()).into_response()
+    impl IntoResponse for Error {
+        fn into_response(self) -> axum::response::Response {
+            (self.status_code(), self.to_string()).into_response()
         }
     }
 }

--- a/crates/lightbridge-authz-usage/src/handlers/query.rs
+++ b/crates/lightbridge-authz-usage/src/handlers/query.rs
@@ -51,20 +51,16 @@ pub async fn query_usage(
         return Err(bad_request(message));
     }
 
-    let points = state
-        .repo
-        .query_usage(&input)
-        .await
-        .map_err(|err| {
-            // Preserve the status mapping (e.g. transient pool failures -> 503)
-            // while returning the structured UsageErrorResponse JSON shape.
-            (
-                err.status_code(),
-                Json(UsageErrorResponse {
-                    error: err.to_string(),
-                }),
-            )
-        })?;
+    let points = state.repo.query_usage(&input).await.map_err(|err| {
+        // Preserve the status mapping (e.g. transient pool failures -> 503)
+        // while returning the structured UsageErrorResponse JSON shape.
+        (
+            err.status_code(),
+            Json(UsageErrorResponse {
+                error: err.to_string(),
+            }),
+        )
+    })?;
 
     Ok((StatusCode::OK, Json(UsageQueryResponse { points })))
 }

--- a/crates/lightbridge-authz-usage/src/handlers/query.rs
+++ b/crates/lightbridge-authz-usage/src/handlers/query.rs
@@ -1,9 +1,11 @@
 use crate::UsageState;
 use crate::models::{UsageErrorResponse, UsageQueryRequest, UsageQueryResponse};
+use crate::repo::validate_bucket_interval;
 use axum::{Json, extract::State, http::StatusCode};
-use lightbridge_authz_core::{Error, Result};
 use std::sync::Arc;
 use tracing::{info, instrument, warn};
+
+type UsageHandlerResult<T> = std::result::Result<T, (StatusCode, Json<UsageErrorResponse>)>;
 
 #[utoipa::path(
     post,
@@ -11,7 +13,8 @@ use tracing::{info, instrument, warn};
     request_body = UsageQueryRequest,
     responses(
         (status = 200, body = UsageQueryResponse),
-        (status = 400, body = UsageErrorResponse)
+        (status = 400, body = UsageErrorResponse),
+        (status = 500, body = UsageErrorResponse)
     ),
     tag = "usage"
 )]
@@ -19,7 +22,7 @@ use tracing::{info, instrument, warn};
 pub async fn query_usage(
     State(state): State<Arc<UsageState>>,
     Json(input): Json<UsageQueryRequest>,
-) -> Result<(StatusCode, Json<UsageQueryResponse>)> {
+) -> UsageHandlerResult<(StatusCode, Json<UsageQueryResponse>)> {
     info!(
         "querying usage with scope={:?}, scope_id={}, bucket={}, limit={}",
         input.scope, input.scope_id, input.bucket, input.limit
@@ -29,26 +32,47 @@ pub async fn query_usage(
             "invalid time range: start_time={} end_time={}",
             input.start_time, input.end_time
         );
-        return Err(Error::Database(
-            "start_time must be before end_time".to_string(),
-        ));
+        return Err(bad_request("start_time must be before end_time"));
     }
 
     if input.scope_id.trim().is_empty() {
         warn!("missing scope_id for usage query");
-        return Err(Error::Database(
-            "scope_id is required for usage queries".to_string(),
-        ));
+        return Err(bad_request("scope_id is required for usage queries"));
     }
 
     if input.limit == 0 {
         warn!("invalid limit for usage query: limit=0");
-        return Err(Error::Database(
-            "limit must be greater than zero".to_string(),
-        ));
+        return Err(bad_request("limit must be greater than zero"));
     }
 
-    let points = state.repo.query_usage(&input).await?;
+    if let Err(message) = validate_bucket_interval(&input.bucket) {
+        warn!("invalid bucket for usage query: bucket={}", input.bucket);
+        return Err(bad_request(message));
+    }
+
+    let points = state
+        .repo
+        .query_usage(&input)
+        .await
+        .map_err(|err| server_error(err.to_string()))?;
 
     Ok((StatusCode::OK, Json(UsageQueryResponse { points })))
+}
+
+fn bad_request(message: impl Into<String>) -> (StatusCode, Json<UsageErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(UsageErrorResponse {
+            error: message.into(),
+        }),
+    )
+}
+
+fn server_error(message: impl Into<String>) -> (StatusCode, Json<UsageErrorResponse>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(UsageErrorResponse {
+            error: message.into(),
+        }),
+    )
 }

--- a/crates/lightbridge-authz-usage/src/handlers/query.rs
+++ b/crates/lightbridge-authz-usage/src/handlers/query.rs
@@ -14,7 +14,8 @@ type UsageHandlerResult<T> = std::result::Result<T, (StatusCode, Json<UsageError
     responses(
         (status = 200, body = UsageQueryResponse),
         (status = 400, body = UsageErrorResponse),
-        (status = 500, body = UsageErrorResponse)
+        (status = 500, body = UsageErrorResponse),
+        (status = 503, body = UsageErrorResponse)
     ),
     tag = "usage"
 )]
@@ -54,7 +55,16 @@ pub async fn query_usage(
         .repo
         .query_usage(&input)
         .await
-        .map_err(|err| server_error(err.to_string()))?;
+        .map_err(|err| {
+            // Preserve the status mapping (e.g. transient pool failures -> 503)
+            // while returning the structured UsageErrorResponse JSON shape.
+            (
+                err.status_code(),
+                Json(UsageErrorResponse {
+                    error: err.to_string(),
+                }),
+            )
+        })?;
 
     Ok((StatusCode::OK, Json(UsageQueryResponse { points })))
 }
@@ -62,15 +72,6 @@ pub async fn query_usage(
 fn bad_request(message: impl Into<String>) -> (StatusCode, Json<UsageErrorResponse>) {
     (
         StatusCode::BAD_REQUEST,
-        Json(UsageErrorResponse {
-            error: message.into(),
-        }),
-    )
-}
-
-fn server_error(message: impl Into<String>) -> (StatusCode, Json<UsageErrorResponse>) {
-    (
-        StatusCode::INTERNAL_SERVER_ERROR,
         Json(UsageErrorResponse {
             error: message.into(),
         }),

--- a/crates/lightbridge-authz-usage/src/repo.rs
+++ b/crates/lightbridge-authz-usage/src/repo.rs
@@ -97,7 +97,7 @@ impl StoreRepo {
             "querying usage with scope={:?}, scope_id={}, bucket={}, limit={}",
             input.scope, input.scope_id, input.bucket, input.limit
         );
-        validate_bucket_interval(&input.bucket)?;
+        validate_bucket_interval(&input.bucket).map_err(Error::Database)?;
 
         let mut group_set = HashSet::new();
         for group in &input.group_by {
@@ -254,7 +254,7 @@ fn append_dimension(
     }
 }
 
-fn validate_bucket_interval(bucket: &str) -> Result<()> {
+pub(crate) fn validate_bucket_interval(bucket: &str) -> std::result::Result<(), String> {
     static BUCKET_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
         regex::Regex::new(r"^\d+\s+(second|seconds|minute|minutes|hour|hours|day|days)$")
             .expect("bucket regex should be valid")
@@ -263,9 +263,7 @@ fn validate_bucket_interval(bucket: &str) -> Result<()> {
     if BUCKET_RE.is_match(bucket.trim()) {
         Ok(())
     } else {
-        Err(Error::Database(
-            "bucket must look like `5 minutes`, `1 hour`, or `1 day`".to_string(),
-        ))
+        Err("bucket must look like `5 minutes`, `1 hour`, or `1 day`".to_string())
     }
 }
 

--- a/crates/lightbridge-authz-usage/tests/usage_tests.rs
+++ b/crates/lightbridge-authz-usage/tests/usage_tests.rs
@@ -57,7 +57,38 @@ async fn query_usage_returns_bad_request_when_time_window_is_invalid() {
 
     let result = query_usage(axum::extract::State(state), Json(req)).await;
 
-    assert!(result.is_err());
+    let err = match result {
+        Ok(_) => panic!("invalid query should be rejected"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    assert_eq!(err.1.0.error, "start_time must be before end_time");
+}
+
+#[tokio::test]
+async fn query_usage_returns_bad_request_when_bucket_is_invalid() {
+    let req = UsageQueryRequest {
+        bucket: "hourly".to_string(),
+        ..base_request()
+    };
+
+    let state = Arc::new(UsageState {
+        repo: Arc::new(MockUsageRepo { points: vec![] }),
+    });
+
+    let result = query_usage(axum::extract::State(state), Json(req)).await;
+
+    let err = match result {
+        Ok(_) => panic!("invalid bucket should be rejected"),
+        Err(err) => err,
+    };
+
+    assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        err.1.0.error,
+        "bucket must look like `5 minutes`, `1 hour`, or `1 day`"
+    );
 }
 
 #[tokio::test]

--- a/docs/lightbridge-query-api.md
+++ b/docs/lightbridge-query-api.md
@@ -154,16 +154,25 @@ This handler performs a small set of input validations (see [`crates/lightbridge
 - `limit` must be greater than 0
 - `bucket` must match the supported interval format (see [`crates/lightbridge-authz-usage/src/repo.rs`](crates/lightbridge-authz-usage/src/repo.rs:257))
 
-Current behaviour to be aware of:
-
-- Many invalid-input cases are returned as `Error::Database(...)`, which maps to **HTTP 500** and a **plain-text** body (not JSON) via the shared error response mapping in [`crates/lightbridge-authz-core/src/error.rs`](crates/lightbridge-authz-core/src/error.rs:1).
-- SQLx errors are mapped to status codes based on SQLx error kind. For example, connection pool failures can surface as **503**.
-
 Example invalid time window:
 
-```text
-HTTP/1.1 500 Internal Server Error
-Database error: start_time must be before end_time
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+```
+
+```json
+{
+  "error": "start_time must be before end_time"
+}
+```
+
+Example invalid bucket:
+
+```json
+{
+  "error": "bucket must look like `5 minutes`, `1 hour`, or `1 day`"
+}
 ```
 
 ## Constraints
@@ -181,10 +190,10 @@ Database error: start_time must be before end_time
 - The usage query endpoint is exercised by the integration test runner in [`.docker/it/servers_it.py`](.docker/it/servers_it.py:1).
 - The endpoint is also described at a high level in [`README.md`](README.md:118) and [`docs/usage-api.md`](docs/usage-api.md:1).
 
-### Known quirks and limitations
+### Known limitations
 
-- Input validation errors currently surface as plain-text errors (often with HTTP 500) due to the shared error-to-response mapping in [`crates/lightbridge-authz-core/src/error.rs`](crates/lightbridge-authz-core/src/error.rs:1).
 - The API is aggregation-first: no raw events, no server-side ranking/top-N, no offset pagination, and fixed ordering by time bucket.
+- Frontend integration guidance lives in [`usage-frontend-integration.md`](usage-frontend-integration.md:1).
 
 ## How to?
 

--- a/docs/usage-api.md
+++ b/docs/usage-api.md
@@ -8,8 +8,12 @@
   - Accepts `application/x-protobuf` or OTLP JSON payloads compatible with `ExportTraceServiceRequest`.
 - `POST /v1/otel/metrics`
   - Accepts `application/x-protobuf` or OTLP JSON payloads compatible with `ExportMetricsServiceRequest`.
-- `POST /v1/usage/query`
+- `POST /v1/otel/logs`
+  - Accepts `application/x-protobuf` or OTLP JSON payloads compatible with `ExportLogsServiceRequest`.
+- `POST /usage/v1/usage/query`
   - Single query endpoint for scoped, bucketed usage retrieval.
+- `GET /usage/v1/usage/docs`
+  - Swagger UI for the usage query and OTEL ingest contract.
 
 ## Query request
 
@@ -29,11 +33,68 @@
 }
 ```
 
+## Query response
+
+```json
+{
+  "points": [
+    {
+      "bucket_start": "2026-02-20T00:00:00Z",
+      "account_id": null,
+      "project_id": null,
+      "user_id": null,
+      "model": "gpt-4.1",
+      "metric_name": null,
+      "signal_type": null,
+      "requests": 12,
+      "usage_value": 34567.0,
+      "total_cost": 1.23,
+      "prompt_tokens": 20000,
+      "completion_tokens": 14567,
+      "total_tokens": 34567
+    }
+  ]
+}
+```
+
+Dimensions that are not listed in `group_by` are returned as `null`. Numeric fields are aggregates for each `bucket_start` plus selected grouping dimensions.
+
+## Validation errors
+
+Invalid query input returns HTTP `400` with JSON:
+
+```json
+{
+  "error": "start_time must be before end_time"
+}
+```
+
+The query endpoint validates:
+
+- `start_time` must be before `end_time`
+- `scope_id` must not be blank
+- `limit` must be greater than zero
+- `bucket` must look like `5 minutes`, `1 hour`, or `1 day`
+
 ## Scope semantics
 
 - `scope=user` filters by `user_id = scope_id`
 - `scope=project` filters by `project_id = scope_id`
 - `scope=account` filters by `account_id = scope_id`
+
+`scope` and `filters` are cumulative. For example, `scope=project` with `scope_id=proj_1` and `filters.project_id=proj_2` is valid JSON, but it returns no points because no row can satisfy both filters.
+
+## Frontend use
+
+For dashboard integration, treat this as a read-model API:
+
+- Keep query construction in one typed client function.
+- Use presets for common ranges such as today, 7 days, 30 days, and current billing period.
+- Choose the coarsest useful bucket for the chart: `1 hour` for one day, `1 day` for weeks or months.
+- Use `group_by: []` for KPI totals, `group_by: ["model"]` for model breakdowns, and `group_by: ["user_id"]` for user tables.
+- Sort top-N views client-side because the API always orders by `bucket_start ASC`.
+
+See `usage-frontend-integration.md` for a concrete TypeScript integration plan.
 
 ## Migrations
 

--- a/docs/usage-frontend-integration.md
+++ b/docs/usage-frontend-integration.md
@@ -1,0 +1,191 @@
+# Usage Frontend Integration Plan
+
+This guide describes how a frontend should consume the `lightbridge-authz-usage` query API without spreading usage-specific rules across screens.
+
+## API contract
+
+- Base path: `/usage`
+- Query endpoint: `POST /usage/v1/usage/query`
+- Content type: `application/json`
+- Authentication: currently none at the usage service boundary
+- Response shape: `{ "points": UsageSeriesPoint[] }`
+- Error shape for invalid query input: `{ "error": string }`
+
+The endpoint is aggregation-first. It always returns bucketed timeseries points, not raw usage events.
+
+## TypeScript types
+
+```ts
+export type UsageScope = "user" | "project" | "account";
+
+export type UsageGroupBy =
+  | "account_id"
+  | "project_id"
+  | "user_id"
+  | "model"
+  | "metric_name"
+  | "signal_type";
+
+export type UsageQueryFilters = {
+  account_id?: string;
+  project_id?: string;
+  user_id?: string;
+  model?: string;
+  metric_name?: string;
+  signal_type?: string;
+};
+
+export type UsageQueryRequest = {
+  scope: UsageScope;
+  scope_id: string;
+  start_time: string;
+  end_time: string;
+  bucket?: string;
+  filters?: UsageQueryFilters;
+  group_by?: UsageGroupBy[];
+  limit?: number;
+};
+
+export type UsageSeriesPoint = {
+  bucket_start: string;
+  account_id: string | null;
+  project_id: string | null;
+  user_id: string | null;
+  model: string | null;
+  metric_name: string | null;
+  signal_type: string | null;
+  requests: number;
+  usage_value: number;
+  total_cost: number;
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+};
+
+export type UsageQueryResponse = {
+  points: UsageSeriesPoint[];
+};
+```
+
+## API client
+
+Keep this as the only frontend code that knows the raw endpoint path.
+
+```ts
+export async function queryUsage(
+  baseUrl: string,
+  input: UsageQueryRequest,
+  signal?: AbortSignal,
+): Promise<UsageQueryResponse> {
+  const response = await fetch(`${baseUrl}/usage/v1/usage/query`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    signal,
+  });
+
+  if (!response.ok) {
+    const fallback = `Usage query failed with HTTP ${response.status}`;
+    const body = await response.json().catch(() => ({ error: fallback }));
+    throw new Error(typeof body.error === "string" ? body.error : fallback);
+  }
+
+  return response.json() as Promise<UsageQueryResponse>;
+}
+```
+
+## Query presets
+
+Use explicit query builders per dashboard need. That keeps chart components simple.
+
+```ts
+export function projectUsageTimeseries(params: {
+  projectId: string;
+  start: Date;
+  end: Date;
+  bucket: "1 hour" | "1 day";
+  model?: string;
+}): UsageQueryRequest {
+  return {
+    scope: "project",
+    scope_id: params.projectId,
+    start_time: params.start.toISOString(),
+    end_time: params.end.toISOString(),
+    bucket: params.bucket,
+    filters: params.model ? { model: params.model } : {},
+    group_by: ["model"],
+    limit: 1000,
+  };
+}
+
+export function accountModelBreakdown(params: {
+  accountId: string;
+  start: Date;
+  end: Date;
+}): UsageQueryRequest {
+  return {
+    scope: "account",
+    scope_id: params.accountId,
+    start_time: params.start.toISOString(),
+    end_time: params.end.toISOString(),
+    bucket: "30 days",
+    filters: {},
+    group_by: ["model"],
+    limit: 1000,
+  };
+}
+
+export function userUsageTable(params: {
+  projectId: string;
+  start: Date;
+  end: Date;
+}): UsageQueryRequest {
+  return {
+    scope: "project",
+    scope_id: params.projectId,
+    start_time: params.start.toISOString(),
+    end_time: params.end.toISOString(),
+    bucket: "1 day",
+    filters: {},
+    group_by: ["user_id", "model"],
+    limit: 1000,
+  };
+}
+```
+
+## Dashboard mapping
+
+Recommended first screens:
+
+- Overview KPIs: `group_by: []`, show `requests`, `total_tokens`, `total_cost`.
+- Usage over time: `group_by: ["model"]`, render one chart series per model.
+- Model breakdown: `group_by: ["model"]`, aggregate returned points client-side by model and sort by `total_cost` or `total_tokens`.
+- User breakdown: `group_by: ["user_id"]` or `["user_id", "model"]`, aggregate client-side for a table.
+- Filters: expose model and date range first; add user and signal type only when users need debugging depth.
+
+## Frontend data rules
+
+- Treat missing dimension values as `null`, not empty strings.
+- Prefer UTC internally and format dates only at the display layer.
+- Use `1 hour` buckets for single-day charts and `1 day` buckets for multi-day charts.
+- Keep `limit` high enough for `bucket_count * group_count`; otherwise the service may truncate the result.
+- For top-N lists, request a coarse bucket and sort in the frontend because the API orders by time.
+
+## Integration sequence
+
+1. Add the typed API client and request/response types.
+2. Add date range helpers that output UTC `start_time`, `end_time`, and a bucket.
+3. Build query presets for the dashboard views.
+4. Add one data hook per preset, with request cancellation for date/filter changes.
+5. Normalize `points` into chart series and table rows in selector/helper functions.
+6. Add UI states for loading, empty result, and `{ error }` responses.
+7. Add contract tests or mocked API tests for the client, especially `400` error parsing.
+
+## Open API questions
+
+These are product/API decisions to make before expanding the dashboard:
+
+- Should the service add dedicated summary endpoints for KPI cards?
+- Should top-N sorting and pagination move server-side for large tenants?
+- Should usage query become protected by the same bearer middleware as the authz API?
+- Should the frontend expose `signal_type` and `metric_name`, or keep them as support/debug filters?


### PR DESCRIPTION
## Summary
- Normalized the usage query path in the docs to `/usage/v1/usage/query` and aligned the OpenAPI references.
- Changed query validation to return structured `400` JSON errors for bad input instead of generic database failures.
- Added targeted tests for invalid time windows and invalid bucket formats.
- Added a frontend integration guide with TypeScript types, a client wrapper, query presets, and dashboard usage patterns.

## Testing
- `cargo test -p lightbridge-authz-usage-rest`
- `cargo clippy -p lightbridge-authz-usage-rest --all-targets --all-features -- -D warnings`
- `cargo fix --allow-dirty`
- `cargo check --all-targets --all-features`
- `just all-checks` was blocked at `cargo deny check` by pre-existing `rustls-webpki` advisories in `Cargo.lock`