### PR TITLE
Handle duplicate usage inserts as accepted requests

### DIFF
--- a/crates/lightbridge-authz-core/src/error.rs
+++ b/crates/lightbridge-authz-core/src/error.rs
@@ -16,6 +16,9 @@ pub enum Error {
     #[error("Conflict: {0}")]
     Conflict(String),
 
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+
     #[error("Any: {0}")]
     Any(#[from] anyhow::Error),
 
@@ -62,6 +65,7 @@ mod axum_impl {
                 Error::Yaml(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 Error::NotFound => StatusCode::NOT_FOUND,
                 Error::Conflict(_) => StatusCode::CONFLICT,
+                Error::BadRequest(_) => StatusCode::BAD_REQUEST,
                 Error::Any(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 Error::AddrParseError(_) => StatusCode::INTERNAL_SERVER_ERROR,
                 Error::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/lightbridge-authz-mcp/src/lib.rs
+++ b/crates/lightbridge-authz-mcp/src/lib.rs
@@ -164,6 +164,7 @@ fn to_tool_error(error: Error) -> ErrorData {
     match error {
         Error::NotFound => ErrorData::resource_not_found("not found", None),
         Error::Conflict(msg) => ErrorData::invalid_params(msg, None),
+        Error::BadRequest(msg) => ErrorData::invalid_params(msg, None),
         other => ErrorData::internal_error(other.to_string(), None),
     }
 }

--- a/crates/lightbridge-authz-usage/src/handlers/ingest.rs
+++ b/crates/lightbridge-authz-usage/src/handlers/ingest.rs
@@ -71,8 +71,6 @@ const TOTAL_TOKENS_KEYS: [&str; 5] = [
     "genai.usage.total_tokens",
 ];
 const USAGE_VALUE_KEYS: [&str; 3] = ["usage_value", "usage", "gen_ai.usage.total_tokens"];
-// FIX: Added "io.envoy.ai_gateway.llm_custom_total_cost" to match the attribute key
-// written by the Envoy AI Gateway extproc when it writes the CEL-computed cost.
 const COST_KEYS: [&str; 4] = [
     "io.envoy.ai_gateway.llm_custom_total_cost",
     "custom_total_cost",
@@ -98,7 +96,7 @@ pub async fn ingest_traces(
 ) -> Result<(StatusCode, Json<IngestResponse>)> {
     let payload = decode_trace_request(&headers, &body)?;
     let events = extract_trace_events(payload);
-    let accepted_events = state.repo.insert_usage_events(&events).await?;
+    let accepted_events = persist_events(&state, "trace", &events).await?;
 
     info!("accepted {} trace events", accepted_events);
 
@@ -126,7 +124,7 @@ pub async fn ingest_metrics(
 ) -> Result<(StatusCode, Json<IngestResponse>)> {
     let payload = decode_metrics_request(&headers, &body)?;
     let events = extract_metric_events(payload);
-    let accepted_events = state.repo.insert_usage_events(&events).await?;
+    let accepted_events = persist_events(&state, "metric", &events).await?;
 
     info!("accepted {} metric events", accepted_events);
 
@@ -154,7 +152,7 @@ pub async fn ingest_logs(
 ) -> Result<(StatusCode, Json<IngestResponse>)> {
     let payload = decode_logs_request(&headers, &body)?;
     let events = extract_log_events(payload);
-    let accepted_events = state.repo.insert_usage_events(&events).await?;
+    let accepted_events = persist_events(&state, "log", &events).await?;
 
     info!("accepted {} log events", accepted_events);
 
@@ -169,12 +167,12 @@ fn decode_logs_request(headers: &HeaderMap, body: &[u8]) -> Result<ExportLogsSer
     if is_json_content(headers) {
         serde_json::from_slice(&body).map_err(|e| {
             warn!("invalid OTLP logs JSON payload: {e}");
-            Error::Database(format!("invalid OTLP logs JSON payload: {e}"))
+            Error::BadRequest(format!("invalid OTLP logs JSON payload: {e}"))
         })
     } else {
         ExportLogsServiceRequest::decode(body.as_slice()).map_err(|e| {
             warn!("invalid OTLP logs protobuf payload: {e}");
-            Error::Database(format!("invalid OTLP logs protobuf payload: {e}"))
+            Error::BadRequest(format!("invalid OTLP logs protobuf payload: {e}"))
         })
     }
 }
@@ -197,9 +195,67 @@ fn decode_maybe_gzip(headers: &HeaderMap, body: &[u8]) -> Result<Vec<u8>> {
     let mut out = Vec::new();
     decoder.read_to_end(&mut out).map_err(|e| {
         warn!("invalid gzip body: {e}");
-        Error::Database(format!("invalid gzip body: {e}"))
+        Error::BadRequest(format!("invalid gzip body: {e}"))
     })?;
     Ok(out)
+}
+
+async fn persist_events(
+    state: &UsageState,
+    signal_type: &str,
+    events: &[UsageEvent],
+) -> Result<usize> {
+    validate_events(events)?;
+    let persisted_events = state.repo.insert_usage_events(events).await?;
+
+    if persisted_events < events.len() {
+        warn!(
+            "usage {signal_type} insert persisted {} of {} decoded events; treating remaining events as accepted",
+            persisted_events,
+            events.len()
+        );
+        Ok(events.len())
+    } else {
+        Ok(persisted_events)
+    }
+}
+
+fn validate_events(events: &[UsageEvent]) -> Result<()> {
+    for event in events {
+        if event.signal_type.trim().is_empty() {
+            return Err(Error::BadRequest("signal_type is required".to_string()));
+        }
+
+        if !event.usage_value.is_finite() {
+            return Err(Error::BadRequest("usage_value must be finite".to_string()));
+        }
+
+        if event.total_cost.is_some_and(|value| !value.is_finite()) {
+            return Err(Error::BadRequest("total_cost must be finite".to_string()));
+        }
+
+        if event.request_count < 0 {
+            return Err(Error::BadRequest(
+                "request_count cannot be negative".to_string(),
+            ));
+        }
+
+        if [
+            event.prompt_tokens,
+            event.completion_tokens,
+            event.total_tokens,
+        ]
+        .into_iter()
+        .flatten()
+        .any(|value| value < 0)
+        {
+            return Err(Error::BadRequest(
+                "token counts cannot be negative".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 fn extract_log_events(payload: ExportLogsServiceRequest) -> Vec<UsageEvent> {
@@ -262,12 +318,12 @@ fn decode_trace_request(headers: &HeaderMap, body: &[u8]) -> Result<ExportTraceS
     if is_json_content(headers) {
         serde_json::from_slice(body).map_err(|e| {
             warn!("invalid OTLP trace JSON payload: {e}");
-            Error::Database(format!("invalid OTLP trace JSON payload: {e}"))
+            Error::BadRequest(format!("invalid OTLP trace JSON payload: {e}"))
         })
     } else {
         ExportTraceServiceRequest::decode(body).map_err(|e| {
             warn!("invalid OTLP trace protobuf payload: {e}");
-            Error::Database(format!("invalid OTLP trace protobuf payload: {e}"))
+            Error::BadRequest(format!("invalid OTLP trace protobuf payload: {e}"))
         })
     }
 }
@@ -276,12 +332,12 @@ fn decode_metrics_request(headers: &HeaderMap, body: &[u8]) -> Result<ExportMetr
     if is_json_content(headers) {
         serde_json::from_slice(body).map_err(|e| {
             warn!("invalid OTLP metrics JSON payload: {e}");
-            Error::Database(format!("invalid OTLP metrics JSON payload: {e}"))
+            Error::BadRequest(format!("invalid OTLP metrics JSON payload: {e}"))
         })
     } else {
         ExportMetricsServiceRequest::decode(body).map_err(|e| {
             warn!("invalid OTLP metrics protobuf payload: {e}");
-            Error::Database(format!("invalid OTLP metrics protobuf payload: {e}"))
+            Error::BadRequest(format!("invalid OTLP metrics protobuf payload: {e}"))
         })
     }
 }

--- a/crates/lightbridge-authz-usage/src/handlers/query.rs
+++ b/crates/lightbridge-authz-usage/src/handlers/query.rs
@@ -29,21 +29,21 @@ pub async fn query_usage(
             "invalid time range: start_time={} end_time={}",
             input.start_time, input.end_time
         );
-        return Err(Error::Database(
+        return Err(Error::BadRequest(
             "start_time must be before end_time".to_string(),
         ));
     }
 
     if input.scope_id.trim().is_empty() {
         warn!("missing scope_id for usage query");
-        return Err(Error::Database(
+        return Err(Error::BadRequest(
             "scope_id is required for usage queries".to_string(),
         ));
     }
 
     if input.limit == 0 {
         warn!("invalid limit for usage query: limit=0");
-        return Err(Error::Database(
+        return Err(Error::BadRequest(
             "limit must be greater than zero".to_string(),
         ));
     }

--- a/crates/lightbridge-authz-usage/src/repo.rs
+++ b/crates/lightbridge-authz-usage/src/repo.rs
@@ -82,7 +82,7 @@ impl StoreRepo {
                 .push_bind(event.prompt_tokens)
                 .push_bind(event.completion_tokens)
                 .push_bind(event.total_tokens)
-                .push_bind(event.total_cost)
+                .push_bind(event.total_cost.unwrap_or(0.0))
                 .push_bind(&event.attributes);
         });
 
@@ -263,7 +263,7 @@ fn validate_bucket_interval(bucket: &str) -> Result<()> {
     if BUCKET_RE.is_match(bucket.trim()) {
         Ok(())
     } else {
-        Err(Error::Database(
+        Err(Error::BadRequest(
             "bucket must look like `5 minutes`, `1 hour`, or `1 day`".to_string(),
         ))
     }

--- a/crates/lightbridge-authz-usage/tests/usage_tests.rs
+++ b/crates/lightbridge-authz-usage/tests/usage_tests.rs
@@ -1,25 +1,31 @@
-use axum::Json;
 use axum::http::StatusCode;
+use axum::{Json, body::Bytes, http::HeaderMap};
 use chrono::{Duration, Utc};
-use lightbridge_authz_core::{Result, async_trait};
+use lightbridge_authz_core::{Error, Result, async_trait};
 use lightbridge_authz_usage_rest::UsageRepoTrait;
 use lightbridge_authz_usage_rest::UsageState;
+use lightbridge_authz_usage_rest::handlers::ingest::ingest_logs;
 use lightbridge_authz_usage_rest::handlers::query::query_usage;
 use lightbridge_authz_usage_rest::models::{
     UsageGroupBy, UsageQueryFilters, UsageQueryRequest, UsageScope, UsageSeriesPoint,
 };
 use lightbridge_authz_usage_rest::repo::UsageEvent;
+use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value};
+use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+use prost::Message;
 use std::sync::Arc;
 
 #[derive(Debug)]
 struct MockUsageRepo {
     points: Vec<UsageSeriesPoint>,
+    inserted_events: usize,
 }
 
 #[async_trait]
 impl UsageRepoTrait for MockUsageRepo {
     async fn insert_usage_events(&self, _events: &[UsageEvent]) -> Result<usize> {
-        Ok(0)
+        Ok(self.inserted_events)
     }
 
     async fn query_usage(&self, _input: &UsageQueryRequest) -> Result<Vec<UsageSeriesPoint>> {
@@ -52,12 +58,18 @@ async fn query_usage_returns_bad_request_when_time_window_is_invalid() {
     };
 
     let state = Arc::new(UsageState {
-        repo: Arc::new(MockUsageRepo { points: vec![] }),
+        repo: Arc::new(MockUsageRepo {
+            points: vec![],
+            inserted_events: 0,
+        }),
     });
 
     let result = query_usage(axum::extract::State(state), Json(req)).await;
 
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(Error::BadRequest(message)) if message == "start_time must be before end_time"
+    ));
 }
 
 #[tokio::test]
@@ -65,6 +77,7 @@ async fn query_usage_returns_timeseries_points_when_query_is_valid() {
     let now = Utc::now();
     let state = Arc::new(UsageState {
         repo: Arc::new(MockUsageRepo {
+            inserted_events: 1,
             points: vec![UsageSeriesPoint {
                 bucket_start: now,
                 account_id: Some("acct_1".to_string()),
@@ -91,4 +104,96 @@ async fn query_usage_returns_timeseries_points_when_query_is_valid() {
     assert_eq!(response.0, StatusCode::OK);
     assert_eq!(response.1.0.points.len(), 1);
     assert_eq!(response.1.0.points[0].project_id.as_deref(), Some("proj_1"));
+}
+
+#[tokio::test]
+async fn ingest_logs_treats_noop_insert_as_success() {
+    let state = Arc::new(UsageState {
+        repo: Arc::new(MockUsageRepo {
+            points: vec![],
+            inserted_events: 0,
+        }),
+    });
+
+    let response = ingest_logs(
+        axum::extract::State(state),
+        HeaderMap::new(),
+        encoded_log_request(),
+    )
+    .await
+    .expect("noop insert should still acknowledge OTLP logs");
+
+    assert_eq!(response.0, StatusCode::ACCEPTED);
+    assert_eq!(response.1.0.accepted_events, 1);
+}
+
+#[tokio::test]
+async fn ingest_logs_rejects_invalid_protobuf_as_bad_request() {
+    let state = Arc::new(UsageState {
+        repo: Arc::new(MockUsageRepo {
+            points: vec![],
+            inserted_events: 0,
+        }),
+    });
+
+    let result = ingest_logs(
+        axum::extract::State(state),
+        HeaderMap::new(),
+        Bytes::from_static(b"not protobuf"),
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(Error::BadRequest(message))
+            if message.contains("invalid OTLP logs protobuf payload")
+    ));
+}
+
+fn encoded_log_request() -> Bytes {
+    let request = ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            resource: None,
+            scope_logs: vec![ScopeLogs {
+                scope: None,
+                log_records: vec![LogRecord {
+                    time_unix_nano: 1_700_000_000_000_000_000,
+                    severity_text: "INFO".to_string(),
+                    attributes: vec![
+                        string_attr("account_id", "acct_1"),
+                        string_attr("project_id", "proj_1"),
+                        int_attr("prompt_tokens", 8),
+                        int_attr("completion_tokens", 4),
+                    ],
+                    ..Default::default()
+                }],
+                schema_url: String::new(),
+            }],
+            schema_url: String::new(),
+        }],
+    };
+
+    let mut encoded = Vec::new();
+    request
+        .encode(&mut encoded)
+        .expect("log request should encode");
+    Bytes::from(encoded)
+}
+
+fn string_attr(key: &str, value: &str) -> KeyValue {
+    KeyValue {
+        key: key.to_string(),
+        value: Some(AnyValue {
+            value: Some(any_value::Value::StringValue(value.to_string())),
+        }),
+    }
+}
+
+fn int_attr(key: &str, value: i64) -> KeyValue {
+    KeyValue {
+        key: key.to_string(),
+        value: Some(AnyValue {
+            value: Some(any_value::Value::IntValue(value)),
+        }),
+    }
 }


### PR DESCRIPTION
## Summary
- Treat usage ingest decode and validation failures as true `400 Bad Request` responses instead of generic database errors.
- Accept duplicate or no-op persistence results as successful OTLP ingests, while logging the short write.
- Fix usage persistence to default missing `total_cost` to `0.0` so rows satisfy the `NOT NULL` schema.
- Add regression coverage for no-op log inserts and malformed OTLP payloads.

## Testing
- `cargo test -p lightbridge-authz-usage-rest`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `just all-checks` was blocked by existing `cargo deny` advisories in `Cargo.lock`