### PR TITLE
Fix ARM Trivy scans and extend integration test readiness timeouts

### DIFF
--- a/.docker/it/authorino_it.py
+++ b/.docker/it/authorino_it.py
@@ -66,6 +66,7 @@ def post_form(url: str, form_data: dict):
 
 def wait_until_ready() -> None:
     start = time.time()
+    last_error = "readiness checks have not run yet"
     while True:
         try:
             request_json("GET", f"{API_URL}/health", insecure_tls=True)
@@ -76,10 +77,11 @@ def wait_until_ready() -> None:
             )
             log("API, OPA, and Keycloak are ready")
             return
-        except Exception:
+        except Exception as err:
+            last_error = str(err) or err.__class__.__name__
             if time.time() - start > MAX_WAIT_SECONDS:
                 raise TimeoutError(
-                    f"services not ready after {MAX_WAIT_SECONDS}s"
+                    f"services not ready after {MAX_WAIT_SECONDS}s: {last_error}"
                 ) from None
             time.sleep(2)
 

--- a/.docker/it/servers_it.py
+++ b/.docker/it/servers_it.py
@@ -139,6 +139,7 @@ def wait_until_ready() -> None:
     ]
 
     start = time.time()
+    last_error = "readiness checks have not run yet"
     while True:
         try:
             for probe_url in probe_urls:
@@ -151,10 +152,11 @@ def wait_until_ready() -> None:
             )
             log("all probes and Keycloak discovery endpoint are ready")
             return
-        except Exception:
+        except Exception as err:
+            last_error = str(err) or err.__class__.__name__
             if time.time() - start > MAX_WAIT_SECONDS:
                 raise TimeoutError(
-                    f"services not ready after {MAX_WAIT_SECONDS}s"
+                    f"services not ready after {MAX_WAIT_SECONDS}s: {last_error}"
                 ) from None
             time.sleep(2)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          TRIVY_IMAGE_SRC: remote
+          TRIVY_PLATFORM: ${{ matrix.platform }}
         with:
           image-ref: ${{ steps.build-image.outputs.version-tag }}
           format: 'table'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
 dependencies = [
  "cc",
  "cmake",
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.9"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -431,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1273,7 +1273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2004,7 +2004,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2370,11 +2370,12 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.47"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2695,9 +2696,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.50"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -3385,7 +3386,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3423,9 +3424,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3851,7 +3852,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3909,7 +3910,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3920,9 +3921,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4657,7 +4658,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5169,9 +5170,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.5.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
  "indexmap",
  "serde",
@@ -5181,9 +5182,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.5.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5456,7 +5457,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/compose.it.yaml
+++ b/compose.it.yaml
@@ -19,7 +19,7 @@ services:
       USERNAME: "test@admin"
       PASSWORD: "test"
       AUTHORINO_BASIC: "authorino:change-me"
-      MAX_WAIT_SECONDS: "180"
+      MAX_WAIT_SECONDS: "300"
     command: ["python", "/it/authorino_it.py"]
 
   it-servers:
@@ -47,5 +47,5 @@ services:
       USERNAME: "test@admin"
       PASSWORD: "test"
       AUTHORINO_BASIC: "authorino:change-me"
-      MAX_WAIT_SECONDS: "180"
+      MAX_WAIT_SECONDS: "300"
     command: ["python", "/it/servers_it.py"]


### PR DESCRIPTION
**Summary**
- Configure the CI Trivy scan to use the matrix platform so ARM image jobs scan the image they actually built instead of falling back to `linux/amd64`.
- Increase the integration test readiness window to reduce false timeouts on slower CI runners.
- Include the last readiness failure in timeout errors to make future CI failures easier to diagnose.

**Testing**
- `python3 -m py_compile` for the updated integration test scripts.
- `docker compose -f compose.yaml -f compose.it.yaml config --quiet` to validate the compose overlay.
- `git diff --check` to catch formatting issues.
- `just all-checks` was not fully green because `cargo deny check` is currently blocked by an existing `Cargo.lock` vulnerability update issue unrelated to these edits.