### PR TITLE
Restore the original usage init migration

### DIFF
--- a/migrations-usage/20260223000001_init_usage.sql
+++ b/migrations-usage/20260223000001_init_usage.sql
@@ -4,9 +4,7 @@ CREATE TABLE IF NOT EXISTS usage_events (
     signal_type TEXT NOT NULL,
     account_id TEXT,
     project_id TEXT,
-    api_key_id TEXT,
     user_id TEXT,
-    user_name TEXT,
     model TEXT,
     metric_name TEXT,
     usage_value DOUBLE PRECISION NOT NULL DEFAULT 0,
@@ -21,9 +19,7 @@ CREATE TABLE IF NOT EXISTS usage_events (
 CREATE INDEX IF NOT EXISTS idx_usage_events_observed_at ON usage_events (observed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_usage_events_account_time ON usage_events (account_id, observed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_usage_events_project_time ON usage_events (project_id, observed_at DESC);
-CREATE INDEX IF NOT EXISTS idx_usage_events_api_key_time ON usage_events (api_key_id, observed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_usage_events_user_time ON usage_events (user_id, observed_at DESC);
-CREATE INDEX IF NOT EXISTS idx_usage_events_user_name_time ON usage_events (user_name, observed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_usage_events_model_time ON usage_events (model, observed_at DESC);
 
 DO $$


### PR DESCRIPTION
## Summary
- Revert the edits made to `migrations-usage/20260223000001_init_usage.sql` so the already-applied migration matches what is stored in production.
- Keep the separate forward migration for the new usage event subject dimensions.
- This avoids SQLx checksum errors like `migration 20260223000001 was previously applied but has been modified`.

## Testing
- `cargo test -p lightbridge-authz-usage-migrate`
- `cargo test -p lightbridge-authz-usage-rest`
- `just all-checks`