### PR TITLE
chore: adopt AI Governance kit

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Documentation
     url: https://github.com/ADORSYS-GIS/wazuh-cert-oauth2#readme
     about: Check the documentation before opening an issue
+  - name: AI Governance
+    url: https://adorsys-gis.github.io/ai-governance/
+    about: Templates, Definition of Ready/Done, and the AI working agreement

--- a/.github/ISSUE_TEMPLATE/dev-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/dev-ticket.yml
@@ -1,0 +1,167 @@
+name: Development Ticket
+description: Implementation work, bugs, refactors, technical tasks, spikes, or operational work.
+title: "[Ticket]: "
+labels: ["ticket"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for **implementation work**, bugs, refactors, technical tasks, spikes, or operational work.
+
+        If the developer cannot explain the intent, the ticket is not ready.
+        See the governance source of truth: https://adorsys-gis.github.io/ai-governance/
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: Select one.
+      options:
+        - Feature
+        - Bug
+        - Refactor
+        - Technical debt
+        - Spike / Investigation
+        - Security
+        - Performance
+        - Documentation
+        - Operational task
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: We need to [do what] because [why]. Describe the expected result in plain but precise language.
+      placeholder: |
+        We need to … because …
+
+        Expected result:
+        >
+    validations:
+      required: true
+
+  - type: textarea
+    id: intent
+    attributes:
+      label: Intent
+      description: The real intention of this ticket. If the developer cannot explain this intent, the ticket is not ready.
+    validations:
+      required: true
+
+  - type: textarea
+    id: source-of-truth
+    attributes:
+      label: Source of truth (links)
+      description: Epic/story, product decision, bug report/incident, customer request, ADR, technical investigation, security requirement. Use full URLs or #123 references.
+      placeholder: |
+        Link the epic/story, product decision, incident, customer request, ADR, or security requirement.
+        No source of truth means this ticket must be challenged — no source of truth = not ready.
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current Behavior
+      description: How the system behaves today, with evidence (logs, screenshots, error messages, metrics, user reports).
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: How the system should behave after this ticket is completed.
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Testable Given/When/Then criteria, safe error handling, no regressions, tests added/updated, verification evidence provided.
+      placeholder: |
+        - [ ] Given …, when …, then …
+        - [ ] Error cases are handled safely.
+        - [ ] Existing behavior is not broken.
+        - [ ] Relevant tests are added or updated.
+        - [ ] Verification evidence is provided.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of Scope
+      description: What this ticket does not include. Do not silently implement out-of-scope work.
+
+  - type: textarea
+    id: technical-context
+    attributes:
+      label: Technical Context
+      description: Relevant files, services, modules, or systems; important technical notes; known constraints.
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks
+      description: Potential risks and their mitigations.
+
+  - type: textarea
+    id: test-plan
+    attributes:
+      label: Test Plan
+      description: Required checks (unit/integration/e2e/manual/regression/security/performance), commands to run, and expected results.
+
+  - type: textarea
+    id: verification-evidence
+    attributes:
+      label: Verification evidence
+      description: Test output, manual verification steps, screenshots/video, logs checked, metrics checked, known remaining limitations.
+      placeholder: |
+        Test output: …
+        Manual verification steps: …
+        Logs / metrics checked: …
+    validations:
+      required: true
+
+  - type: input
+    id: human-owner
+    attributes:
+      label: Human accountable owner
+      description: The person who accepts responsibility for the final result.
+      placeholder: "@github-handle / Name"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: ai-usage
+    attributes:
+      label: AI Usage Declaration
+      description: Declare how AI was used. AI output is not truth.
+      options:
+        - label: Drafting the ticket
+        - label: Understanding code
+        - label: Proposing implementation
+        - label: Generating code
+        - label: Refactoring
+        - label: Generating tests
+        - label: Reviewing the diff
+        - label: Writing documentation
+        - label: Not used
+        - label: I have declared AI usage above (ticked the relevant items, or "Not used").
+          required: true
+
+  - type: checkboxes
+    id: human-verification
+    attributes:
+      label: Human verification completed
+      description: Tick what you completed. The final accountability box is required; the governance CI check on the PR is the substantive gate.
+      options:
+        - label: I understood the intent
+        - label: I checked the source of truth
+        - label: I reviewed all AI-generated text/code
+        - label: I verified the implementation manually
+        - label: I verified the tests
+        - label: I checked for hallucinated assumptions
+        - label: I documented remaining risks
+        - label: I am the accountable owner and accept responsibility for this ticket.
+          required: true

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,151 @@
+name: Epic
+description: A large initiative spanning multiple stories with a meaningful business or technical objective.
+title: "[Epic]: "
+labels: ["epic"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the work is **large**, spans multiple tickets, and represents a meaningful business or technical objective.
+
+        An epic exists to solve a real problem — not merely to produce code, tickets, documentation, or AI-generated artifacts.
+        See the governance source of truth: https://adorsys-gis.github.io/ai-governance/
+
+  - type: textarea
+    id: executive-summary
+    attributes:
+      label: Executive Summary
+      description: We want to [outcome] because [business, user, operational, or technical reason]. This epic exists to solve [the real problem].
+      placeholder: |
+        We want to … because …
+        This epic exists to solve …
+    validations:
+      required: true
+
+  - type: textarea
+    id: strategic-intent
+    attributes:
+      label: Strategic Intent
+      description: The core intention in 1–3 sentences. A person must be able to explain this verbally without reading this document.
+      placeholder: The intent of this epic is …
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem Statement
+      description: Current pains/problems, and the impact on users, developers/operations, and business/security/compliance.
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired-outcome
+    attributes:
+      label: Desired Outcome
+      description: What is true when this epic is complete. Describe the observable improvement.
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope (In / Out)
+      description: What is clearly included and what is explicitly excluded. Anything not listed must be clarified before implementation.
+      placeholder: |
+        ### In Scope
+        -
+
+        ### Out of Scope
+        -
+    validations:
+      required: true
+
+  - type: textarea
+    id: source-of-truth
+    attributes:
+      label: Source of truth (links)
+      description: Product decisions, stakeholder input, incidents, ADRs, designs, compliance requirements. Use full URLs or #123 references.
+      placeholder: |
+        Link the product decision, stakeholder request, incident, ADR, design, or compliance requirement.
+        If no source of truth exists, this epic is NOT ready — do not proceed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: stakeholders
+    attributes:
+      label: Stakeholders
+      description: Product Owner, Technical Lead, Delivery Owner, Security/Compliance, Engineering Team.
+
+  - type: textarea
+    id: assumptions
+    attributes:
+      label: Key Assumptions
+      description: Each assumption must be validated, rejected, or converted into a risk before delivery.
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Technical, security, compliance, timeline, dependency, and operational constraints.
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks
+      description: Risk / Probability / Impact / Mitigation.
+
+  - type: textarea
+    id: success-metrics
+    attributes:
+      label: Success metrics
+      description: How we will know this epic succeeded. Metric / current value / target value / measurement source. Measure outcomes, not activity.
+      placeholder: |
+        | Metric | Current | Target | Source |
+        | ------ | ------- | ------ | ------ |
+    validations:
+      required: true
+
+  - type: textarea
+    id: child-stories
+    attributes:
+      label: Child User Stories
+      description: Each child story must have its own acceptance criteria and verification evidence.
+
+  - type: input
+    id: human-owner
+    attributes:
+      label: Human accountable owner
+      description: The person who owns the final decision and accepts responsibility for this epic.
+      placeholder: "@github-handle / Name"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: ai-usage
+    attributes:
+      label: AI Usage Declaration
+      description: Declare how AI was used. AI output is not truth.
+      options:
+        - label: Drafting
+        - label: Summarization
+        - label: Research
+        - label: Ticket decomposition
+        - label: Technical proposal
+        - label: Not used
+        - label: I have declared AI usage above (ticked the relevant items, or "Not used").
+          required: true
+
+  - type: checkboxes
+    id: human-verification
+    attributes:
+      label: Human verification completed
+      description: Tick what you completed. The final accountability box is required; the governance CI check on the PR is the substantive gate.
+      options:
+        - label: Intent checked against source of truth
+        - label: Scope reviewed by Product Owner
+        - label: Technical feasibility reviewed by Technical Lead
+        - label: Risks reviewed
+        - label: Acceptance criteria reviewed
+        - label: No unverified AI claim remains
+        - label: I am the accountable owner and accept responsibility for this epic.
+          required: true

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -1,0 +1,148 @@
+name: User Story
+description: A user need or a valuable capability, with testable acceptance criteria.
+title: "[Story]: "
+labels: ["user-story"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the work describes **a user need** or **a valuable capability**.
+
+        A story is not ready if its intent is only copied from an AI-generated summary.
+        See the governance source of truth: https://adorsys-gis.github.io/ai-governance/
+
+  - type: textarea
+    id: story-statement
+    attributes:
+      label: Story Statement
+      description: As a [user/actor], I want [capability/action], so that [benefit/outcome].
+      placeholder: |
+        As a …,
+        I want …,
+        so that …
+    validations:
+      required: true
+
+  - type: textarea
+    id: real-intent
+    attributes:
+      label: Real Intent
+      description: Explain why this story matters. Not ready if the intention is only copied from an AI-generated summary.
+    validations:
+      required: true
+
+  - type: textarea
+    id: background
+    attributes:
+      label: Background and Context
+      description: Current behavior, limitation, and pain; and why we need to change it.
+
+  - type: textarea
+    id: source-of-truth
+    attributes:
+      label: Source of truth (links)
+      description: Customer/user request, product decision, design, incident/bug report, data/metric, architecture decision. Use full URLs or #123 references.
+      placeholder: |
+        Link the customer request, product decision, design, incident, metric, or ADR.
+        If the source of truth is missing, the story must NOT enter sprint planning — no source of truth means not ready.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Functional (Given/When/Then), negative/edge cases, and non-functional criteria. Must be testable.
+      placeholder: |
+        ### Functional
+        - [ ] Given …, when …, then …
+
+        ### Negative / Edge Cases
+        - [ ] Given …, when …, then …
+
+        ### Non-Functional
+        - [ ] Performance / Security / Observability / Accessibility / Compatibility
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of Scope
+      description: What this story does not include. If someone wants these, they must create a separate story.
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies and Blockers
+      description: What this story depends on and what blocks it.
+
+  - type: textarea
+    id: assumptions
+    attributes:
+      label: Assumptions
+      description: Before implementation, the developer must decide whether each assumption is acceptable or needs clarification.
+
+  - type: textarea
+    id: implementation-notes
+    attributes:
+      label: Implementation Notes
+      description: Suggested approach — guidance, not unquestionable truth. The developer may challenge it for a safer, simpler, more maintainable option.
+
+  - type: textarea
+    id: test-expectations
+    attributes:
+      label: Test Expectations
+      description: Unit / integration / e2e / manual / regression / security / performance, plus required test cases.
+
+  - type: textarea
+    id: verification-evidence
+    attributes:
+      label: Verification evidence
+      description: Test results (link/command/screenshot), manual verification notes, logs/metrics checked, recordings, reviewer focus. No verification evidence means the story is not done.
+      placeholder: |
+        Test results: …
+        Manual verification notes: …
+        Logs / metrics checked: …
+    validations:
+      required: true
+
+  - type: input
+    id: human-owner
+    attributes:
+      label: Human accountable owner
+      description: The person who owns the final decision and accepts responsibility for this story.
+      placeholder: "@github-handle / Name"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: ai-usage
+    attributes:
+      label: AI Usage Declaration
+      description: Declare how AI was used. AI output is not truth.
+      options:
+        - label: Drafting this story
+        - label: Refining acceptance criteria
+        - label: Suggesting implementation
+        - label: Generating code
+        - label: Generating tests
+        - label: Reviewing code
+        - label: Not used
+        - label: I have declared AI usage above (ticked the relevant items, or "Not used").
+          required: true
+
+  - type: checkboxes
+    id: human-verification
+    attributes:
+      label: Human verification completed
+      description: Tick what you completed. The final accountability box is required; the governance CI check on the PR is the substantive gate.
+      options:
+        - label: I checked the story against the source of truth
+        - label: I confirmed the acceptance criteria
+        - label: I reviewed the implementation approach
+        - label: I verified generated code manually
+        - label: I verified generated tests manually
+        - label: I removed or corrected unsupported AI claims
+        - label: I am the accountable owner and accept responsibility for this story.
+          required: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,17 @@
+<!-- ai-governance:stanza -->
+<!-- BEGIN: AI Governance stanza (managed by ADORSYS-GIS/ai-governance) -->
+## AI Governance
+
+AI may accelerate the work, but humans own intent, verification, and consequences.
+AI output is not truth: review AI-generated code as untrusted, and never submit work you cannot explain.
+
+When opening issues or pull requests in this repo:
+
+- Use the provided **issue forms** (Epic, User Story, Dev Ticket) and the **pull request template** — do not open blank issues/PRs.
+- Fill in the **AI Usage Declaration** honestly (what AI was used for, what you verified).
+- Include a **source-of-truth link** (a URL or `#123` reference). No source of truth means the work is not ready.
+- Provide **verification evidence** (commands, logs, links, or checked verification boxes). No evidence means it is not done.
+
+Source of truth and full doctrine: https://adorsys-gis.github.io/ai-governance/
+This stanza is intentionally thin — read the site; do not duplicate the doctrine here.
+<!-- END: AI Governance stanza -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,3 +42,27 @@ How was this tested?
 - [ ] Integration tests
 - [ ] Manual testing with `just it-test`
 - [ ] Other:
+
+---
+
+## Intent / Source of Truth
+
+Why this change exists, and the source of truth (issue link, ADR, decision, or incident).
+
+Source of truth: <link or #issue>
+
+## Verification
+
+Evidence this change works — commands run, output, screenshots, or links (see **Testing** above).
+
+- [ ] Verified locally (`just all-checks`)
+
+## AI Usage Declaration
+
+Declare whether/how AI was used:
+
+- [ ] Not used
+- [ ] AI-assisted (describe what AI was used for below)
+
+> AI may accelerate the work, but it must not launder ignorance into polished artifacts.
+> Governance: https://adorsys-gis.github.io/ai-governance/

--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -1,0 +1,20 @@
+# Per-repo caller workflow for AI Governance PR enforcement.
+#
+# Drop this file at .github/workflows/governance.yml in a consuming repo to opt in.
+# It delegates to the reusable workflow hosted in ADORSYS-GIS/ai-governance, which
+# fails the PR if its body is missing an AI Usage Declaration, a source-of-truth
+# reference, or verification evidence — and posts a sticky comment listing what's missing.
+#
+# Source of truth: https://adorsys-gis.github.io/ai-governance/
+name: AI Governance
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  governance:
+    uses: ADORSYS-GIS/ai-governance/.github/workflows/governance-check.yml@main
+    permissions:
+      pull-requests: write
+      contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -544,3 +544,23 @@ In Compose, `authz-migrate` runs before API/OPA start.
 
 - A brand-new `lightbridge-migrate` chart (aliased `migration` under `charts/lightbridge`) runs `lightbridge-authz migrate --config-path /tmp/lightbridge-config/config.yaml` as a `pre-install/pre-upgrade` job so schema migrations happen before the API/OPA controllers become active. It reuses the ambient `lightbridge-authz-config` config map, shares the same image artifacts, and exposes TTL/backoff knobs to keep the job brief.
 - That migration chart is now built on the `bjw-s/common v4` app-template library, so the job/configmap/secret skeletal resources are rendered by the shared loader instead of bespoke templates, keeping the chart plumbing consistent with the rest of the stack.
+
+<!-- ai-governance:stanza -->
+## AI Governance
+
+<!-- BEGIN: AI Governance stanza (managed by ADORSYS-GIS/ai-governance) -->
+## AI Governance
+
+AI may accelerate the work, but humans own intent, verification, and consequences.
+AI output is not truth: review AI-generated code as untrusted, and never submit work you cannot explain.
+
+When opening issues or pull requests in this repo:
+
+- Use the provided **issue forms** (Epic, User Story, Dev Ticket) and the **pull request template** — do not open blank issues/PRs.
+- Fill in the **AI Usage Declaration** honestly (what AI was used for, what you verified).
+- Include a **source-of-truth link** (a URL or `#123` reference). No source of truth means the work is not ready.
+- Provide **verification evidence** (commands, logs, links, or checked verification boxes). No evidence means it is not done.
+
+Source of truth and full doctrine: https://adorsys-gis.github.io/ai-governance/
+This stanza is intentionally thin — read the site; do not duplicate the doctrine here.
+<!-- END: AI Governance stanza -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+<!-- ai-governance:stanza -->
+<!-- BEGIN: AI Governance stanza (managed by ADORSYS-GIS/ai-governance) -->
+## AI Governance
+
+AI may accelerate the work, but humans own intent, verification, and consequences.
+AI output is not truth: review AI-generated code as untrusted, and never submit work you cannot explain.
+
+When opening issues or pull requests in this repo:
+
+- Use the provided **issue forms** (Epic, User Story, Dev Ticket) and the **pull request template** — do not open blank issues/PRs.
+- Fill in the **AI Usage Declaration** honestly (what AI was used for, what you verified).
+- Include a **source-of-truth link** (a URL or `#123` reference). No source of truth means the work is not ready.
+- Provide **verification evidence** (commands, logs, links, or checked verification boxes). No evidence means it is not done.
+
+Source of truth and full doctrine: https://adorsys-gis.github.io/ai-governance/
+This stanza is intentionally thin — read the site; do not duplicate the doctrine here.
+<!-- END: AI Governance stanza -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+This repository follows the [ADORSYS-GIS AI Governance](https://adorsys-gis.github.io/ai-governance/) discipline:
+**AI may accelerate the work, but humans own intent, verification, and consequences.**
+
+## How to contribute
+
+- **Open issues** with the structured forms — [Epic](.github/ISSUE_TEMPLATE/epic.yml),
+  [User Story](.github/ISSUE_TEMPLATE/user-story.yml), or
+  [Development Ticket](.github/ISSUE_TEMPLATE/dev-ticket.yml). Blank issues are disabled on purpose.
+- **Open pull requests** using the [pull request template](.github/PULL_REQUEST_TEMPLATE.md). Fill in every section.
+- Always complete the **AI Usage Declaration**, link a **source of truth**, and attach **verification evidence**.
+
+## Definition of Ready / Done gates
+
+Work is **Ready** only when its intent is clear, its source of truth is linked, its scope and acceptance criteria are explicit, and any AI-generated content has been reviewed by a human. Work is **Done** only when acceptance criteria are met, tests pass, verification evidence is attached, and a named human owner accepts responsibility for the result. A governance CI check enforces that every PR body declares AI usage, references a source of truth, and shows verification evidence — see the [AI Working Agreement](https://adorsys-gis.github.io/ai-governance/12-ai-working-agreement) and the [Doctrine](https://adorsys-gis.github.io/ai-governance/13-doctrine).


### PR DESCRIPTION
Adopts the ADORSYS-GIS AI Governance kit for this repo.

## Intent
Standardise issues, PRs, and AI-usage discipline by adopting the canonical governance kit.
Source of truth: https://adorsys-gis.github.io/ai-governance/

## What changed (added only where not already present)
- `.github/ISSUE_TEMPLATE/*` — epic, user-story, and dev-ticket issue forms + chooser config.
- `.github/PULL_REQUEST_TEMPLATE.md` — the governance PR template.
- `.github/workflows/governance.yml` — opts this repo into the reusable PR governance check.
- `CONTRIBUTING.md` — links the forms, PR template, and DoR/DoD gates.
- Governance stanza appended to `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`
  (never overwritten). Any file this repo already maintains is left untouched.

## Verification
- [x] File contents copied verbatim from the reviewed canonical kit.
- [x] Each file added only if absent; existing files left untouched.

Generated and opened by the sync script:

```
$ zsh scripts/sync-templates.zsh         # dry-run preview
$ zsh scripts/sync-templates.zsh --apply # opened this PR
```

## AI Usage Declaration
- [x] Not used — contents are copied verbatim from the reviewed canonical kit by a deterministic script.

Human accountable owner: the maintainer who ran the sync.

Generated by `scripts/sync-templates.zsh` in ADORSYS-GIS/ai-governance.